### PR TITLE
fix: wire real activity feed; improve exec command labels (#2, #3)

### DIFF
--- a/ClawView/ClawView/Models/AgentModels.swift
+++ b/ClawView/ClawView/Models/AgentModels.swift
@@ -1,0 +1,244 @@
+import Foundation
+
+// MARK: - Agent Status Models
+
+enum AgentHealth: String, Codable {
+    case normal = "normal"
+    case takingAWhile = "taking_a_while"
+    case stuck = "stuck"
+    case idle = "idle"
+}
+
+enum ConnectionState: String {
+    case localNetwork
+    case sshTunnel
+    case disconnected
+    case error
+}
+
+struct SubAgentInfo: Identifiable, Codable {
+    let id: String
+    let label: String
+    let status: String
+    let durationSeconds: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id, label, status
+        case durationSeconds = "duration_seconds"
+    }
+}
+
+struct AgentCost: Codable {
+    let sessionTotal: Double
+
+    enum CodingKeys: String, CodingKey {
+        case sessionTotal = "session_total"
+    }
+}
+
+/// A single real activity entry from the Gateway API.
+/// Decoded from the `_recentActivity` array in `/api/clawview/status`.
+struct RecentActivityEntry: Identifiable, Codable {
+    let id: UUID
+    let time: Date
+    let text: String
+
+    enum CodingKeys: String, CodingKey {
+        case time, text
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = UUID()
+        self.text = try container.decode(String.self, forKey: .text)
+        // time is an ISO8601 string
+        let timeString = try container.decode(String.self, forKey: .time)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: timeString) {
+            self.time = date
+        } else {
+            // Fallback without fractional seconds
+            formatter.formatOptions = [.withInternetDateTime]
+            self.time = formatter.date(from: timeString) ?? Date()
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        try container.encode(formatter.string(from: time), forKey: .time)
+        try container.encode(text, forKey: .text)
+    }
+
+    /// Human-readable "HH:mm" from the entry's timestamp
+    var formattedTime: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: time)
+    }
+}
+
+struct AgentInfo: Identifiable, Codable {
+    let id: String
+    let name: String
+    let emoji: String
+    let role: String
+    let status: String          // "active" | "idle"
+    let activity: String
+    let durationSeconds: Int
+    let health: AgentHealth
+    let lastActivity: Date?
+    let channel: String?
+    let subAgents: [SubAgentInfo]
+    let cost: AgentCost?
+    /// Real activity feed from Gateway — replaces mockActivities in AgentCardView
+    let recentActivity: [RecentActivityEntry]
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, emoji, role, status, activity, health, channel, cost
+        case durationSeconds = "duration_seconds"
+        case lastActivity = "last_activity"
+        case subAgents = "sub_agents"
+        case recentActivity = "_recentActivity"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        emoji = try container.decode(String.self, forKey: .emoji)
+        role = try container.decode(String.self, forKey: .role)
+        status = try container.decode(String.self, forKey: .status)
+        activity = try container.decode(String.self, forKey: .activity)
+        durationSeconds = try container.decodeIfPresent(Int.self, forKey: .durationSeconds) ?? 0
+        health = try container.decodeIfPresent(AgentHealth.self, forKey: .health) ?? .idle
+        channel = try container.decodeIfPresent(String.self, forKey: .channel)
+        cost = try container.decodeIfPresent(AgentCost.self, forKey: .cost)
+        subAgents = try container.decodeIfPresent([SubAgentInfo].self, forKey: .subAgents) ?? []
+        recentActivity = try container.decodeIfPresent([RecentActivityEntry].self, forKey: .recentActivity) ?? []
+
+        // lastActivity — ISO8601 date
+        if let lastActivityStr = try container.decodeIfPresent(String.self, forKey: .lastActivity) {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = formatter.date(from: lastActivityStr) {
+                lastActivity = date
+            } else {
+                formatter.formatOptions = [.withInternetDateTime]
+                lastActivity = formatter.date(from: lastActivityStr)
+            }
+        } else {
+            lastActivity = nil
+        }
+    }
+
+    /// Direct memberwise init — used by fallback session builder in GatewayService.
+    init(id: String, name: String, emoji: String, role: String, status: String,
+         activity: String, durationSeconds: Int, health: AgentHealth,
+         lastActivity: Date?, channel: String?, subAgents: [SubAgentInfo],
+         cost: AgentCost?, recentActivity: [RecentActivityEntry] = []) {
+        self.id = id; self.name = name; self.emoji = emoji; self.role = role
+        self.status = status; self.activity = activity
+        self.durationSeconds = durationSeconds; self.health = health
+        self.lastActivity = lastActivity; self.channel = channel
+        self.subAgents = subAgents; self.cost = cost
+        self.recentActivity = recentActivity
+    }
+
+    // Computed helper
+    var isActive: Bool { status == "active" }
+}
+
+struct SystemStatus: Codable {
+    let hostname: String
+    let uptime: String
+    let connection: String
+    let agents: [AgentInfo]
+    let timestamp: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case hostname, uptime, connection, agents, timestamp
+    }
+}
+
+// MARK: - Activity Log Entry
+
+struct ActivityEntry: Identifiable {
+    let id = UUID()
+    let timestamp: Date
+    let description: String
+
+    var formattedTime: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: timestamp)
+    }
+}
+
+// MARK: - Mock Data
+
+extension SystemStatus {
+    static var mock: SystemStatus {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let mockJSON = """
+        {
+            "hostname": "griffin",
+            "uptime": "4d 12h",
+            "connection": "local",
+            "agents": [
+                {
+                    "id": "main",
+                    "name": "Clawdia",
+                    "emoji": "🦞",
+                    "role": "Chief of Staff",
+                    "status": "active",
+                    "activity": "Coordinating agent team, reviewing morning digest",
+                    "duration_seconds": 240,
+                    "health": "normal",
+                    "last_activity": "2026-03-11T14:28:00Z",
+                    "channel": "1480700058067533886",
+                    "sub_agents": [],
+                    "cost": { "session_total": 0.12 }
+                },
+                {
+                    "id": "jony",
+                    "name": "Steve",
+                    "emoji": "🦞",
+                    "role": "Product",
+                    "status": "active",
+                    "activity": "Writing product spec for ClawView — design review pass",
+                    "duration_seconds": 720,
+                    "health": "taking_a_while",
+                    "last_activity": "2026-03-11T14:25:00Z",
+                    "channel": "1480707570179117167",
+                    "sub_agents": [
+                        { "id": "sub1", "label": "designer-clawview", "status": "running", "duration_seconds": 180 }
+                    ],
+                    "cost": { "session_total": 0.42 }
+                },
+                {
+                    "id": "dev",
+                    "name": "Linus",
+                    "emoji": "⚙️",
+                    "role": "Engineering",
+                    "status": "idle",
+                    "activity": "Idle",
+                    "duration_seconds": 0,
+                    "health": "idle",
+                    "last_activity": "2026-03-11T12:10:00Z",
+                    "channel": "1480700105781678183",
+                    "sub_agents": [],
+                    "cost": null
+                }
+            ]
+        }
+        """
+        let data = mockJSON.data(using: .utf8)!
+        var status = try! decoder.decode(SystemStatus.self, from: data)
+        return status
+    }
+}

--- a/ClawView/ClawView/Views/AgentCardView.swift
+++ b/ClawView/ClawView/Views/AgentCardView.swift
@@ -1,0 +1,252 @@
+import SwiftUI
+
+// MARK: - Agent Card View
+
+struct AgentCardView: View {
+    let agent: AgentInfo
+    let index: Int
+
+    @State private var isExpanded: Bool = false
+    @State private var isHovered: Bool = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Collapsed header (always visible)
+            HStack(alignment: .top, spacing: 10) {
+                // Emoji
+                Text(agent.emoji)
+                    .font(.system(size: 24))
+                    .frame(width: 32, height: 32, alignment: .center)
+
+                // Text column
+                VStack(alignment: .leading, spacing: 4) {
+                    // Name + Role
+                    HStack(spacing: 4) {
+                        Text(agent.name)
+                            .font(.headline)
+                            .fontWeight(.semibold)
+                            .foregroundColor(.primary)
+                        Text("(\(agent.role))")
+                            .font(.headline)
+                            .fontWeight(.regular)
+                            .foregroundColor(.secondary)
+                    }
+
+                    // Activity
+                    Text(agent.isActive ? agent.activity : "Idle")
+                        .font(.subheadline)
+                        .foregroundColor(agent.isActive ? .primary : Color(NSColor.tertiaryLabelColor))
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    // Duration + health
+                    if agent.isActive || agent.health != .idle {
+                        HStack(spacing: 4) {
+                            Image(systemName: "clock")
+                                .font(.system(size: 10))
+                                .foregroundColor(Color(NSColor.tertiaryLabelColor))
+
+                            Text(formattedDuration)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundColor(Color(NSColor.tertiaryLabelColor))
+
+                            Text("·")
+                                .font(.caption)
+                                .foregroundColor(Color(NSColor.tertiaryLabelColor))
+
+                            Circle()
+                                .fill(healthColor)
+                                .frame(width: 6, height: 6)
+
+                            Text(healthLabel)
+                                .font(.system(.caption, weight: .medium))
+                                .foregroundColor(healthColor)
+                        }
+                    } else {
+                        if let lastActivity = agent.lastActivity {
+                            Text("Last active: \(relativeTime(lastActivity))")
+                                .font(.caption)
+                                .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                        }
+                    }
+                }
+
+                Spacer()
+
+                // Chevron
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12))
+                    .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    .animation(.spring(response: 0.35, dampingFraction: 0.85), value: isExpanded)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(
+                isHovered
+                    ? Color(NSColor.quaternaryLabelColor)
+                    : Color.clear
+            )
+            .contentShape(Rectangle())
+            .onHover { hover in
+                withAnimation(.easeOut(duration: 0.15)) {
+                    isHovered = hover
+                }
+            }
+            .onTapGesture {
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                    isExpanded.toggle()
+                }
+            }
+
+            // Expanded detail
+            if isExpanded {
+                ExpandedAgentDetail(agent: agent)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 12)
+                    .transition(
+                        .opacity.combined(with: .offset(y: -4))
+                    )
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var formattedDuration: String {
+        let secs = agent.durationSeconds
+        if secs < 60 { return "\(secs)s" }
+        let mins = secs / 60
+        if mins < 60 { return "\(mins) min" }
+        let hours = mins / 60
+        return "\(hours)h \(mins % 60)m"
+    }
+
+    private var healthColor: Color {
+        switch agent.health {
+        case .normal: return Color(NSColor.systemGreen)
+        case .takingAWhile: return Color(NSColor.systemYellow)
+        case .stuck: return Color(NSColor.systemRed)
+        case .idle: return Color(NSColor.systemGray)
+        }
+    }
+
+    private var healthLabel: String {
+        switch agent.health {
+        case .normal: return "Normal"
+        case .takingAWhile: return "Taking a while"
+        case .stuck: return "Stuck"
+        case .idle: return "Idle"
+        }
+    }
+
+    private func relativeTime(_ date: Date) -> String {
+        let elapsed = Int(Date().timeIntervalSince(date))
+        if elapsed < 60 { return "just now" }
+        if elapsed < 3600 { return "\(elapsed / 60)m ago" }
+        return "\(elapsed / 3600)h ago"
+    }
+}
+
+// MARK: - Expanded Agent Detail
+
+struct ExpandedAgentDetail: View {
+    let agent: AgentInfo
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Container
+            VStack(alignment: .leading, spacing: 12) {
+
+                // Recent Activity — wired to real _recentActivity from Gateway API (#2)
+                VStack(alignment: .leading, spacing: 4) {
+                    sectionHeader("RECENT ACTIVITY")
+                    Divider()
+
+                    if agent.recentActivity.isEmpty {
+                        Text("No recent activity")
+                            .font(.caption)
+                            .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                    } else {
+                        // Show up to 8 entries, most recent last
+                        ForEach(agent.recentActivity.suffix(8)) { entry in
+                            HStack(alignment: .top, spacing: 8) {
+                                Text(entry.formattedTime)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                                    .frame(width: 40, alignment: .leading)
+
+                                Text(entry.text)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(2)
+                            }
+                        }
+                    }
+                }
+
+                // Sub-agents
+                if !agent.subAgents.isEmpty {
+                    VStack(alignment: .leading, spacing: 4) {
+                        sectionHeader("SUB-AGENTS")
+                        Divider()
+
+                        ForEach(agent.subAgents) { sub in
+                            HStack(spacing: 6) {
+                                Circle()
+                                    .fill(Color(NSColor.systemGreen))
+                                    .frame(width: 6, height: 6)
+                                Text(sub.label)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                Spacer()
+                                Text(formatDuration(sub.durationSeconds))
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                            }
+                        }
+                    }
+                }
+
+                // Cost
+                if let cost = agent.cost {
+                    HStack {
+                        Text("Cost: $\(String(format: "%.2f", cost.sessionTotal))")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Spacer()
+                    }
+                }
+
+                // Nudge button
+                Button("Nudge") {
+                    // v1.1 feature
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.mini)
+                .font(.system(.caption, weight: .medium))
+                .frame(height: 24)
+                .disabled(true) // Coming in v1.1
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color(NSColor.quaternarySystemFill))
+            )
+        }
+        .animation(.easeOut(duration: 0.2).delay(0.05), value: true)
+    }
+
+    @ViewBuilder
+    private func sectionHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.system(.caption, weight: .semibold))
+            .foregroundColor(.secondary)
+            .tracking(0.5)
+    }
+
+    private func formatDuration(_ secs: Int) -> String {
+        if secs < 60 { return "\(secs)s" }
+        return "\(secs / 60) min"
+    }
+}

--- a/clawview-status-server.js
+++ b/clawview-status-server.js
@@ -77,15 +77,113 @@ function humaniseToolCall(name, args) {
     case 'exec':
     case 'bash':
     case 'shell': {
-      const cmd = (a.command || '').trim().slice(0, 60);
+      const cmd = (a.command || '').trim();
       if (!cmd) return 'Running command';
-      // Strip dangerous noise, keep first verb
-      const firstWord = cmd.split(/\s+/)[0];
-      const safeVerbs = { git: 'Running git', npm: 'Running npm', node: 'Running script',
-                          python: 'Running script', python3: 'Running script',
-                          curl: 'Fetching URL', brew: 'Running brew',
-                          swift: 'Building Swift', cargo: 'Building Rust' };
-      return safeVerbs[firstWord] || 'Running command';
+
+      // Strip cd prefix (cd /path && actual-command)
+      const withoutCd = cmd.replace(/^cd\s+\S+\s*&&\s*/, '').trim();
+      // Strip env var prefix (VARNAME=value command)
+      const withoutEnv = withoutCd.replace(/^(?:[A-Z_]+=\S+\s+)+/, '').trim();
+      const effective = withoutEnv || withoutCd || cmd;
+      const firstWord = effective.split(/\s+/)[0];
+      const restWords = effective.split(/\s+/).slice(1, 4).join(' ');
+
+      // git operations — extract the subcommand
+      if (firstWord === 'git') {
+        const sub = effective.split(/\s+/)[1] || '';
+        const gitMap = {
+          commit:   'Committing changes',
+          push:     'Pushing to GitHub',
+          pull:     'Pulling from remote',
+          checkout: 'Switching branch',
+          merge:    'Merging branch',
+          clone:    'Cloning repo',
+          fetch:    'Fetching updates',
+          status:   'Checking git status',
+          log:      'Reviewing git log',
+          add:      'Staging changes',
+          diff:     'Reviewing diff',
+          branch:   'Managing branches',
+          rebase:   'Rebasing branch',
+        };
+        return gitMap[sub] || 'Running git';
+      }
+
+      // Build / compile
+      if (firstWord === 'xcodebuild') return 'Building Xcode project';
+      if (firstWord === 'swift') return 'Building Swift';
+      if (firstWord === 'cargo') return 'Building Rust';
+      if (firstWord === 'make') return 'Building project';
+      if (firstWord === 'gcc' || firstWord === 'clang') return 'Compiling code';
+
+      // Package managers
+      if (firstWord === 'npm') {
+        const sub = effective.split(/\s+/)[1] || '';
+        return sub === 'install' ? 'Installing packages' : sub === 'run' ? 'Running npm script' : 'Running npm';
+      }
+      if (firstWord === 'yarn') return 'Running yarn';
+      if (firstWord === 'pip' || firstWord === 'pip3') return 'Installing Python package';
+      if (firstWord === 'brew') return 'Running brew';
+      if (firstWord === 'apt' || firstWord === 'apt-get') return 'Installing package';
+
+      // Scripts
+      if (firstWord === 'node') return 'Running Node.js script';
+      if (firstWord === 'python' || firstWord === 'python3') return 'Running Python script';
+      if (firstWord === 'bash' || firstWord === 'sh') return 'Running shell script';
+      if (firstWord === 'ruby') return 'Running Ruby script';
+
+      // Network / HTTP
+      if (firstWord === 'curl') {
+        // Try to extract a meaningful URL or endpoint
+        const urlMatch = effective.match(/https?:\/\/[^\s"']+/);
+        if (urlMatch) {
+          try {
+            const u = new URL(urlMatch[0]);
+            return `Fetching ${u.hostname}${u.pathname.slice(0, 30)}`;
+          } catch (e) {}
+        }
+        return 'Fetching URL';
+      }
+      if (firstWord === 'wget') return 'Downloading file';
+      if (firstWord === 'gh') {
+        // GitHub CLI — extract subcommand
+        const parts = effective.split(/\s+/);
+        const sub = parts[1] || '';
+        const sub2 = parts[2] || '';
+        const ghMap = {
+          'pr create':  'Opening pull request',
+          'pr merge':   'Merging pull request',
+          'pr comment': 'Commenting on PR',
+          'pr diff':    'Reviewing PR diff',
+          'pr view':    'Viewing pull request',
+          'issue list': 'Listing issues',
+          'issue view': 'Viewing issue',
+        };
+        return ghMap[`${sub} ${sub2}`] || ghMap[sub] || 'Running gh';
+      }
+
+      // File operations
+      if (firstWord === 'cp') return 'Copying files';
+      if (firstWord === 'mv') return 'Moving files';
+      if (firstWord === 'rm' || firstWord === 'trash') return 'Removing files';
+      if (firstWord === 'mkdir') return 'Creating directory';
+      if (firstWord === 'ls' || firstWord === 'find') return 'Listing files';
+      if (firstWord === 'cat' || firstWord === 'head' || firstWord === 'tail') return 'Reading file';
+      if (firstWord === 'grep' || firstWord === 'rg') return 'Searching files';
+      if (firstWord === 'open') return 'Opening application';
+
+      // System
+      if (firstWord === 'osascript') return 'Running AppleScript';
+      if (firstWord === 'launchctl') return 'Managing launch agent';
+      if (firstWord === 'pgrep' || firstWord === 'ps') return 'Checking processes';
+      if (firstWord === 'kill' || firstWord === 'pkill') return 'Stopping process';
+
+      // If it's a short command we don't recognise, show it trimmed
+      if (firstWord.length > 0 && firstWord.length <= 20 && /^[a-z]/.test(firstWord)) {
+        return `Running ${firstWord}`;
+      }
+
+      return 'Running command';
     }
 
     // Web / search
@@ -284,22 +382,26 @@ function parseSessionFile(sessionFile) {
           }
         }
 
-        // For the activity text: prefer tool call > cleaned text
+        // For the activity text: prefer meaningful assistant text > tool call > fallback
+        // Assistant text often has better context ("Reading SPEC.md", "Reviewing PR diff")
+        // than a raw tool call label. But only if it passes the action-verb filter.
         if (!foundActivity) {
-          if (messageToolCall) {
-            result.activityText = messageToolCall;
-            result.activityType = 'tool_call';
-            result.lastActivityMs = ts || now;
-            foundActivity = true;
-          } else if (messageText) {
+          if (messageText) {
+            // Meaningful text beats a generic tool call like "Running command"
             result.activityText = messageText;
             result.activityType = 'inferred';
+            result.lastActivityMs = ts || now;
+            foundActivity = true;
+          } else if (messageToolCall) {
+            result.activityText = messageToolCall;
+            result.activityType = 'tool_call';
             result.lastActivityMs = ts || now;
             foundActivity = true;
           }
         }
 
         // Build recent activity entries (last 8, within 24h window)
+        // For entries: prefer tool call text (more granular) over assistant narration
         if (ts > 0 && (now - ts) < ENTRY_WINDOW_MS) {
           const entryText = messageToolCall || messageText;
           if (entryText && result.recentEntries.length < 8) {


### PR DESCRIPTION
## Summary

**Fixes #2 — Recent Activity is 100% fabricated**
The expanded agent card was showing hardcoded fake strings: "Processing task", "Loaded workspace context", "Session started". Ripped out entirely. Now wired to `_recentActivity` from the Gateway API.

**Fixes #3 — Activity descriptions useless ('Running command')**
The status server was mapping all `exec` tool calls to the generic string "Running command". Replaced with a smart parser that detects intent: git subcommands, xcodebuild, npm, curl, gh CLI, file ops, etc.

## Changes

### AgentModels.swift
- New `RecentActivityEntry` struct — decodes `{ time, text }` from API
- `AgentInfo` gains `recentActivity: [RecentActivityEntry]` decoded from `_recentActivity` key
- Custom `init(from:)` for robust ISO8601 parsing (with + without fractional seconds)
- Memberwise `init` preserved for GatewayService fallback path

### AgentCardView.swift
- `ExpandedAgentDetail` now reads `agent.recentActivity` directly
- Shows up to 8 real entries with timestamps
- Falls back to 'No recent activity' when empty — no fabricated data

### clawview-status-server.js
- `humaniseToolCall` exec handler: strips `cd /path &&` and env var prefixes, then matches on actual command intent
- git: detects subcommand (commit/push/pull/merge/checkout etc)
- gh CLI: detects pr create/merge/comment/diff
- xcodebuild → 'Building Xcode project'
- curl → 'Fetching \<hostname/path\>'
- npm install → 'Installing packages', npm run → 'Running npm script'
- cp/mv/rm/mkdir/ls → specific file operation labels
- Activity text priority: prefer meaningful assistant text over generic tool label

## Before vs After

| Before | After |
|--------|-------|
| "Processing task" (fake) | "Pushing to GitHub" (real) |
| "Loaded workspace context" (fake) | "Committing changes" (real) |
| "Session started" (fake) | "Building Xcode project" (real) |
| "Running command" × 8 | "Committing changes", "Pushing to GitHub", "Opening pull request" |