### PR TITLE
fix: UX polish batch — header, cost, sub-agents, health, port, nudge (#4,#5,#7,#8,#9,#10,#12,#13,#14,#15)

### DIFF
--- a/ClawView/ClawView/Services/ConnectionManager.swift
+++ b/ClawView/ClawView/Services/ConnectionManager.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Combine
+
+// MARK: - Connection Settings
+
+struct ConnectionSettings: Codable {
+    var host: String
+    var port: Int
+    var useMockData: Bool
+
+    static let defaultSettings = ConnectionSettings(
+        host: "localhost",
+        port: 7317,
+        useMockData: false
+    )
+
+    static let storageKey = "clawview_connection"
+}
+
+// MARK: - ConnectionManager
+
+@MainActor
+class ConnectionManager: ObservableObject {
+    @Published var settings: ConnectionSettings
+    @Published var isFirstRun: Bool
+    @Published var gatewayService = GatewayService.shared
+    @Published var bonjourDiscovery = BonjourDiscovery()
+
+    init() {
+        if let data = UserDefaults.standard.data(forKey: ConnectionSettings.storageKey),
+           let saved = try? JSONDecoder().decode(ConnectionSettings.self, from: data) {
+            self.settings = saved
+            self.isFirstRun = false
+        } else {
+            self.settings = ConnectionSettings.defaultSettings
+            self.isFirstRun = true
+        }
+    }
+
+    func saveAndConnect() {
+        if let data = try? JSONEncoder().encode(settings) {
+            UserDefaults.standard.set(data, forKey: ConnectionSettings.storageKey)
+        }
+        isFirstRun = false
+
+        if settings.useMockData {
+            startMockMode()
+        } else {
+            gatewayService.connect(host: settings.host, port: settings.port)
+        }
+    }
+
+    func startMockMode() {
+        // Inject mock data for UI development
+        gatewayService.systemStatus = SystemStatus.mock
+        gatewayService.connectionState = .localNetwork
+        gatewayService.lastHeartbeat = Date()
+    }
+
+    func reconnect() {
+        if settings.useMockData {
+            startMockMode()
+        } else {
+            gatewayService.connect(host: settings.host, port: settings.port)
+        }
+    }
+
+    func connectToDiscovered(_ host: BonjourDiscovery.DiscoveredHost) {
+        settings.host = host.hostname
+        settings.port = host.port
+        saveAndConnect()
+    }
+}

--- a/ClawView/ClawView/Services/GatewayService.swift
+++ b/ClawView/ClawView/Services/GatewayService.swift
@@ -1,0 +1,269 @@
+import Foundation
+import Combine
+import Network
+
+// MARK: - Gateway API Models
+
+struct GatewaySession: Codable {
+    let key: String
+    let agentId: String?
+    let channel: String?
+    let lastActivity: String?
+    let status: String?
+
+    enum CodingKeys: String, CodingKey {
+        case key
+        case agentId = "agent_id"
+        case channel
+        case lastActivity = "last_activity"
+        case status
+    }
+}
+
+struct GatewaySessionsResponse: Codable {
+    let sessions: [GatewaySession]?
+    // The API might return an array or object — handle both
+}
+
+// MARK: - GatewayService
+
+@MainActor
+class GatewayService: ObservableObject {
+    @Published var systemStatus: SystemStatus?
+    @Published var connectionState: ConnectionState = .disconnected
+    @Published var lastHeartbeat: Date?
+    @Published var errorMessage: String?
+
+    private var pollingTask: Task<Void, Never>?
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var urlSession = URLSession.shared
+
+    // Connection config
+    private(set) var host: String = ""
+    private(set) var port: Int = 7317
+
+    static let shared = GatewayService()
+    private init() {}
+
+    // MARK: - Connection Management
+
+    func connect(host: String, port: Int) {
+        self.host = host
+        self.port = port
+        startPolling()
+    }
+
+    func disconnect() {
+        pollingTask?.cancel()
+        pollingTask = nil
+        webSocketTask?.cancel()
+        webSocketTask = nil
+        connectionState = .disconnected
+    }
+
+    func startPolling() {
+        pollingTask?.cancel()
+        pollingTask = Task {
+            while !Task.isCancelled {
+                await fetchStatus()
+                try? await Task.sleep(nanoseconds: 5_000_000_000) // 5s poll
+            }
+        }
+    }
+
+    // MARK: - API Calls
+
+    func fetchStatus() async {
+        guard !host.isEmpty else {
+            connectionState = .disconnected
+            return
+        }
+
+        // Try the dedicated /api/clawview/status endpoint first
+        // Fall back to /api/sessions if needed
+        do {
+            let status = try await fetchClawViewStatus()
+            systemStatus = status
+            lastHeartbeat = Date()
+            connectionState = .localNetwork
+            errorMessage = nil
+        } catch {
+            // Try fallback
+            do {
+                let status = try await buildStatusFromSessions()
+                systemStatus = status
+                lastHeartbeat = Date()
+                connectionState = .localNetwork
+                errorMessage = nil
+            } catch {
+                connectionState = .disconnected
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func fetchClawViewStatus() async throws -> SystemStatus {
+        let url = URL(string: "http://\(host):\(port)/api/clawview/status")!
+        let (data, response) = try await urlSession.data(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(SystemStatus.self, from: data)
+    }
+
+    private func buildStatusFromSessions() async throws -> SystemStatus {
+        // Fetch sessions list
+        let sessionsURL = URL(string: "http://\(host):\(port)/api/sessions")!
+        let (sessionsData, sessionsResponse) = try await urlSession.data(from: sessionsURL)
+
+        guard let httpResponse = sessionsResponse as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+
+        // Parse raw sessions JSON
+        guard let json = try JSONSerialization.jsonObject(with: sessionsData) as? [String: Any] else {
+            throw URLError(.cannotParseResponse)
+        }
+
+        // Build agent infos from sessions
+        var agents: [AgentInfo] = []
+
+        // Sessions is a dict keyed by session key
+        if let sessions = json as? [String: [String: Any]] {
+            for (key, session) in sessions {
+                let agentId = (session["agent_id"] as? String) ?? key
+                let agentName = resolveAgentName(from: agentId)
+                let agentEmoji = resolveAgentEmoji(from: agentId)
+                let agentRole = resolveAgentRole(from: agentId)
+                let lastMsg = session["last_message"] as? String ?? ""
+                let activity = extractActivity(from: lastMsg, agentName: agentName)
+
+                let lastActivityStr = session["last_activity"] as? String
+                let lastActivity = parseDate(lastActivityStr)
+                let health = computeHealth(lastActivity: lastActivity)
+
+                let agent = AgentInfo(
+                    id: agentId,
+                    name: agentName,
+                    emoji: agentEmoji,
+                    role: agentRole,
+                    status: health == .idle ? "idle" : "active",
+                    activity: activity,
+                    durationSeconds: 0,
+                    health: health,
+                    lastActivity: lastActivity,
+                    channel: session["channel"] as? String,
+                    subAgents: [],
+                    cost: nil
+                )
+                agents.append(agent)
+            }
+        }
+
+        return SystemStatus(
+            hostname: host,
+            uptime: "–",
+            connection: "local",
+            agents: agents,
+            timestamp: Date()
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func resolveAgentName(from id: String) -> String {
+        let map: [String: String] = [
+            "main": "Clawdia",
+            "dev": "Linus",
+            "jony": "Steve",
+            "marketing": "Richard",
+            "research": "Demis",
+            "pa": "Prawn",
+            "intake": "Santa"
+        ]
+        return map[id] ?? id.capitalized
+    }
+
+    private func resolveAgentEmoji(from id: String) -> String {
+        let map: [String: String] = [
+            "main": "🦞",
+            "dev": "⚙️",
+            "jony": "🦞",
+            "marketing": "📣",
+            "research": "🔬",
+            "pa": "🎩",
+            "intake": "🎅"
+        ]
+        return map[id] ?? "🤖"
+    }
+
+    private func resolveAgentRole(from id: String) -> String {
+        let map: [String: String] = [
+            "main": "Chief of Staff",
+            "dev": "Engineering",
+            "jony": "Product",
+            "marketing": "Marketing",
+            "research": "Research",
+            "pa": "Personal Assistant",
+            "intake": "Intake"
+        ]
+        return map[id] ?? "Agent"
+    }
+
+    private func extractActivity(from message: String, agentName: String) -> String {
+        if message.isEmpty { return "Idle" }
+        // Take first ~80 chars of last message as activity
+        let truncated = message.prefix(80)
+        return String(truncated)
+    }
+
+    private func computeHealth(lastActivity: Date?) -> AgentHealth {
+        guard let lastActivity = lastActivity else { return .idle }
+        let elapsed = Date().timeIntervalSince(lastActivity)
+        if elapsed < 120 { return .normal }
+        if elapsed < 600 { return .takingAWhile }
+        return .stuck
+    }
+
+    private func parseDate(_ string: String?) -> Date? {
+        guard let string = string else { return nil }
+        let formatter = ISO8601DateFormatter()
+        return formatter.date(from: string)
+    }
+
+    // MARK: - Computed Properties
+
+    var activeAgents: [AgentInfo] {
+        systemStatus?.agents.filter { $0.isActive } ?? []
+    }
+
+    var allAgents: [AgentInfo] {
+        systemStatus?.agents ?? []
+    }
+
+    var hasStuckAgents: Bool {
+        allAgents.contains { $0.health == .stuck }
+    }
+
+    var hasWarningAgents: Bool {
+        allAgents.contains { $0.health == .takingAWhile || $0.health == .stuck }
+    }
+
+    var heartbeatAge: String {
+        guard let lastHeartbeat = lastHeartbeat else { return "–" }
+        let elapsed = Int(Date().timeIntervalSince(lastHeartbeat))
+        if elapsed < 60 { return "\(elapsed)s" }
+        return "\(elapsed / 60)m"
+    }
+
+    var heartbeatIsStale: Bool {
+        guard let lastHeartbeat = lastHeartbeat else { return true }
+        return Date().timeIntervalSince(lastHeartbeat) > 300
+    }
+}

--- a/ClawView/ClawView/Views/AgentCardView.swift
+++ b/ClawView/ClawView/Views/AgentCardView.swift
@@ -19,18 +19,17 @@ struct AgentCardView: View {
                     .frame(width: 32, height: 32, alignment: .center)
 
                 // Text column
-                VStack(alignment: .leading, spacing: 4) {
-                    // Name + Role
-                    HStack(spacing: 4) {
-                        Text(agent.name)
-                            .font(.headline)
-                            .fontWeight(.semibold)
-                            .foregroundColor(.primary)
-                        Text("(\(agent.role))")
-                            .font(.headline)
-                            .fontWeight(.regular)
-                            .foregroundColor(.secondary)
-                    }
+                VStack(alignment: .leading, spacing: 2) {
+                    // Name — headline only. Role is shown as subordinate caption (#13)
+                    Text(agent.name)
+                        .font(.headline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.primary)
+
+                    // Role — small caption below name, not in parentheses (#13)
+                    Text(agent.role)
+                        .font(.caption)
+                        .foregroundColor(Color(NSColor.tertiaryLabelColor))
 
                     // Activity
                     Text(agent.isActive ? agent.activity : "Idle")
@@ -38,9 +37,11 @@ struct AgentCardView: View {
                         .foregroundColor(agent.isActive ? .primary : Color(NSColor.tertiaryLabelColor))
                         .lineLimit(2)
                         .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, 2)
 
-                    // Duration + health
-                    if agent.isActive || agent.health != .idle {
+                    // Duration row — only for active agents with meaningful duration (#9, #15)
+                    // Idle agents: show "Last active X ago" instead
+                    if agent.isActive && agent.durationSeconds > 0 {
                         HStack(spacing: 4) {
                             Image(systemName: "clock")
                                 .font(.system(size: 10))
@@ -50,21 +51,25 @@ struct AgentCardView: View {
                                 .font(.system(.caption, design: .monospaced))
                                 .foregroundColor(Color(NSColor.tertiaryLabelColor))
 
-                            Text("·")
-                                .font(.caption)
-                                .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                            // Health indicator — only for non-normal states (#14)
+                            // "Normal" adds no signal; silence IS the signal when healthy
+                            if agent.health != .normal && agent.health != .idle {
+                                Text("·")
+                                    .font(.caption)
+                                    .foregroundColor(Color(NSColor.tertiaryLabelColor))
 
-                            Circle()
-                                .fill(healthColor)
-                                .frame(width: 6, height: 6)
+                                Circle()
+                                    .fill(healthColor)
+                                    .frame(width: 6, height: 6)
 
-                            Text(healthLabel)
-                                .font(.system(.caption, weight: .medium))
-                                .foregroundColor(healthColor)
+                                Text(healthLabel)
+                                    .font(.system(.caption, weight: .medium))
+                                    .foregroundColor(healthColor)
+                            }
                         }
-                    } else {
+                    } else if !agent.isActive {
                         if let lastActivity = agent.lastActivity {
-                            Text("Last active: \(relativeTime(lastActivity))")
+                            Text("Last active \(relativeTime(lastActivity))")
                                 .font(.caption)
                                 .foregroundColor(Color(NSColor.tertiaryLabelColor))
                         }
@@ -133,10 +138,10 @@ struct AgentCardView: View {
 
     private var healthLabel: String {
         switch agent.health {
-        case .normal: return "Normal"
+        case .normal: return ""   // Not shown (#14)
         case .takingAWhile: return "Taking a while"
         case .stuck: return "Stuck"
-        case .idle: return "Idle"
+        case .idle: return ""     // Not shown
         }
     }
 
@@ -168,7 +173,6 @@ struct ExpandedAgentDetail: View {
                             .font(.caption)
                             .foregroundColor(Color(NSColor.tertiaryLabelColor))
                     } else {
-                        // Show up to 8 entries, most recent last
                         ForEach(agent.recentActivity.suffix(8)) { entry in
                             HStack(alignment: .top, spacing: 8) {
                                 Text(entry.formattedTime)
@@ -185,7 +189,7 @@ struct ExpandedAgentDetail: View {
                     }
                 }
 
-                // Sub-agents
+                // Sub-agents — with proper status colours and identity (#5)
                 if !agent.subAgents.isEmpty {
                     VStack(alignment: .leading, spacing: 4) {
                         sectionHeader("SUB-AGENTS")
@@ -193,40 +197,49 @@ struct ExpandedAgentDetail: View {
 
                         ForEach(agent.subAgents) { sub in
                             HStack(spacing: 6) {
+                                // Dot colour reflects actual status — not hardcoded green (#5)
                                 Circle()
-                                    .fill(Color(NSColor.systemGreen))
+                                    .fill(subAgentStatusColor(sub.status))
                                     .frame(width: 6, height: 6)
-                                Text(sub.label)
+
+                                // Label with fallback for generic "sub-agent" entries (#5)
+                                Text(sub.label == "sub-agent" ? "Sub-agent" : sub.label)
                                     .font(.caption)
                                     .foregroundColor(.secondary)
+
                                 Spacer()
-                                Text(formatDuration(sub.durationSeconds))
-                                    .font(.system(.caption, design: .monospaced))
-                                    .foregroundColor(Color(NSColor.tertiaryLabelColor))
+
+                                // Duration only meaningful for active sub-agents (#5)
+                                if sub.status == "active" {
+                                    Text(formatDuration(sub.durationSeconds))
+                                        .font(.system(.caption, design: .monospaced))
+                                        .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                                } else {
+                                    Text("done")
+                                        .font(.caption)
+                                        .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                                }
                             }
                         }
                     }
                 }
 
-                // Cost
-                if let cost = agent.cost {
+                // Cost — only shown if non-zero and meaningful (#4)
+                // $0.00 means "not tracked", not "free" — hide it
+                if let cost = agent.cost, cost.sessionTotal > 0.001 {
                     HStack {
-                        Text("Cost: $\(String(format: "%.2f", cost.sessionTotal))")
+                        Image(systemName: "dollarsign.circle")
+                            .font(.system(size: 10))
+                            .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                        Text("$\(String(format: "%.2f", cost.sessionTotal)) this session")
                             .font(.caption)
                             .foregroundColor(.secondary)
                         Spacer()
                     }
                 }
 
-                // Nudge button
-                Button("Nudge") {
-                    // v1.1 feature
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.mini)
-                .font(.system(.caption, weight: .medium))
-                .frame(height: 24)
-                .disabled(true) // Coming in v1.1
+                // Nudge button removed — disabled UI is a broken promise (#7)
+                // Will be re-added in v1.1 when Gateway routing is implemented
             }
             .padding(12)
             .background(
@@ -243,6 +256,15 @@ struct ExpandedAgentDetail: View {
             .font(.system(.caption, weight: .semibold))
             .foregroundColor(.secondary)
             .tracking(0.5)
+    }
+
+    /// Sub-agent status → dot colour (#5)
+    private func subAgentStatusColor(_ status: String) -> Color {
+        switch status {
+        case "active":  return Color(NSColor.systemGreen)
+        case "error":   return Color(NSColor.systemRed)
+        default:        return Color(NSColor.systemGray)  // idle, done, unknown
+        }
     }
 
     private func formatDuration(_ secs: Int) -> String {

--- a/ClawView/ClawView/Views/PopoverView.swift
+++ b/ClawView/ClawView/Views/PopoverView.swift
@@ -1,0 +1,287 @@
+import SwiftUI
+
+// MARK: - Main Popover View
+
+struct PopoverView: View {
+    @ObservedObject var gateway: GatewayService
+    @ObservedObject var connectionManager: ConnectionManager
+    @State private var showSettings = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if showSettings {
+                SettingsView(
+                    connectionManager: connectionManager,
+                    onDismiss: { showSettings = false }
+                )
+            } else if connectionManager.isFirstRun {
+                FirstRunView(connectionManager: connectionManager)
+            } else {
+                mainContent
+            }
+        }
+        .frame(width: 320)
+    }
+
+    @ViewBuilder
+    private var mainContent: some View {
+        VStack(spacing: 0) {
+            // Header
+            PopoverHeaderView(gateway: gateway)
+
+            // Body
+            if gateway.connectionState == .disconnected {
+                DisconnectedView(gateway: gateway)
+            } else {
+                AgentListView(gateway: gateway)
+            }
+
+            // Footer
+            PopoverFooterView(
+                gateway: gateway,
+                onSettingsTapped: { showSettings = true }
+            )
+        }
+    }
+}
+
+// MARK: - Header View
+
+struct PopoverHeaderView: View {
+    @ObservedObject var gateway: GatewayService
+    @State private var heartbeatAge: String = "–"
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .center, spacing: 8) {
+                // Status dot
+                Circle()
+                    .fill(connectionDotColor)
+                    .frame(width: 8, height: 8)
+
+                // System name — hostname only, no hardcoded "Mac mini" prefix (#8)
+                Text(gateway.systemStatus?.hostname ?? "OpenClaw")
+                    .font(.system(.title3, design: .default, weight: .semibold))
+                    .foregroundColor(.primary)
+
+                Spacer()
+
+                // "Updated X ago" — plain language, not "Last beat" jargon (#12)
+                HStack(spacing: 2) {
+                    Text("Updated")
+                        .font(.caption)
+                        .foregroundColor(Color(NSColor.tertiaryLabelColor))
+
+                    Text(heartbeatAge == "–" ? "–" : "\(heartbeatAge) ago")
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundColor(heartbeatTextColor)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .frame(height: 56)
+
+            Divider()
+        }
+        .onReceive(timer) { _ in
+            heartbeatAge = gateway.heartbeatAge
+        }
+        .onAppear {
+            heartbeatAge = gateway.heartbeatAge
+        }
+    }
+
+    private var connectionDotColor: Color {
+        switch gateway.connectionState {
+        case .localNetwork: return Color(NSColor.systemGreen)
+        case .sshTunnel: return Color(NSColor.systemBlue)
+        case .disconnected: return Color(NSColor.systemGray)
+        case .error: return Color(NSColor.systemRed)
+        }
+    }
+
+    private var heartbeatTextColor: Color {
+        guard let lastHeartbeat = gateway.lastHeartbeat else {
+            return Color(NSColor.systemRed)
+        }
+        let elapsed = Date().timeIntervalSince(lastHeartbeat)
+        if elapsed < 300 { return Color(NSColor.secondaryLabelColor) }
+        if elapsed < 600 { return Color(NSColor.systemYellow) }
+        return Color(NSColor.systemRed)
+    }
+}
+
+// MARK: - Agent List View
+
+struct AgentListView: View {
+    @ObservedObject var gateway: GatewayService
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                if gateway.allAgents.isEmpty {
+                    IdleStateView()
+                } else {
+                    LazyVStack(spacing: 0) {
+                        ForEach(Array(gateway.allAgents.enumerated()), id: \.element.id) { index, agent in
+                            AgentCardView(agent: agent, index: index)
+
+                            if index < gateway.allAgents.count - 1 {
+                                Divider()
+                                    .padding(.leading, 56) // Align with text, not emoji
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, 8)
+        }
+        .frame(maxHeight: 540) // 640 - 56 (header) - 44 (footer) — v1.1 height fix
+        .scrollIndicators(.hidden)
+    }
+}
+
+// MARK: - Idle State View
+
+struct IdleStateView: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            Text("🌙")
+                .font(.system(size: 24))
+
+            Text("All quiet")
+                .font(.headline)
+                .foregroundColor(.primary)
+
+            Text("No agents are running.\nThe system is idle.")
+                .font(.subheadline)
+                .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 32)
+        .padding(.horizontal, 16)
+    }
+}
+
+// MARK: - Disconnected View
+
+struct DisconnectedView: View {
+    @ObservedObject var gateway: GatewayService
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "wifi.slash")
+                .font(.system(size: 40))
+                .foregroundColor(Color(NSColor.tertiaryLabelColor))
+
+            VStack(spacing: 6) {
+                Text("Can't reach your Mac mini")
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                    .multilineTextAlignment(.center)
+
+                Text("Check that OpenClaw is running\nand your network connection is active.")
+                    .font(.subheadline)
+                    .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                    .multilineTextAlignment(.center)
+            }
+
+            Button("Try Again") {
+                Task {
+                    await gateway.fetchStatus()
+                }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.regular)
+            .frame(width: 120, height: 32)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 32)
+        .padding(.horizontal, 16)
+    }
+}
+
+// MARK: - Footer View
+
+struct PopoverFooterView: View {
+    @ObservedObject var gateway: GatewayService
+    var onSettingsTapped: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+
+            HStack {
+                FooterButton(
+                    label: "Discord",
+                    icon: "arrow.up.forward.square",
+                    enabled: gateway.connectionState != .disconnected
+                ) {
+                    openDiscord()
+                }
+
+                FooterButton(
+                    label: "Processes",
+                    icon: "list.bullet.rectangle",
+                    enabled: false // v1.1
+                ) {
+                    // Future: process viewer
+                }
+
+                FooterButton(
+                    label: "Settings",
+                    icon: "gearshape",
+                    enabled: true,
+                    action: onSettingsTapped
+                )
+            }
+            .padding(.horizontal, 16)
+            .frame(height: 44)
+        }
+    }
+
+    private func openDiscord() {
+        if let url = URL(string: "discord://") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+
+struct FooterButton: View {
+    let label: String
+    let icon: String
+    let enabled: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 12))
+                Text(label)
+                    .font(.system(.caption, weight: .medium))
+            }
+            .foregroundColor(enabled ? Color(NSColor.controlAccentColor) : Color(NSColor.tertiaryLabelColor))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isHovered && enabled ? Color(NSColor.quaternaryLabelColor) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .onHover { hover in
+            withAnimation(.easeOut(duration: 0.15)) {
+                isHovered = hover
+            }
+        }
+        .onExitCommand {
+            isHovered = false
+        }
+    }
+}

--- a/ClawView/ClawView/Views/SettingsView.swift
+++ b/ClawView/ClawView/Views/SettingsView.swift
@@ -65,7 +65,7 @@ struct SettingsView: View {
                                 Text("Port")
                                     .font(.system(.caption, weight: .medium))
                                     .foregroundColor(.secondary)
-                                TextField("3917", text: $portString)
+                                TextField("7317", text: $portString)
                                     .textFieldStyle(.roundedBorder)
                                     .font(.body)
                             }
@@ -96,7 +96,7 @@ struct SettingsView: View {
                     // Save button
                     Button("Save & Connect") {
                         connectionManager.settings.host = host
-                        connectionManager.settings.port = Int(portString) ?? 3917
+                        connectionManager.settings.port = Int(portString) ?? 7317
                         connectionManager.settings.useMockData = useMock
                         connectionManager.saveAndConnect()
                         onDismiss()
@@ -128,7 +128,7 @@ struct FirstRunView: View {
     @ObservedObject var connectionManager: ConnectionManager
 
     @State private var host: String = "localhost"
-    @State private var portString: String = "3917"
+    @State private var portString: String = "7317"
     @State private var isSearching: Bool = false
 
     var body: some View {
@@ -168,7 +168,7 @@ struct FirstRunView: View {
                         Text("Port")
                             .font(.system(.caption, weight: .medium))
                             .foregroundColor(.secondary)
-                        TextField("3917", text: $portString)
+                        TextField("7317", text: $portString)
                             .textFieldStyle(.roundedBorder)
                     }
                 }
@@ -212,7 +212,7 @@ struct FirstRunView: View {
                 // Connect button
                 Button("Connect") {
                     connectionManager.settings.host = host
-                    connectionManager.settings.port = Int(portString) ?? 3917
+                    connectionManager.settings.port = Int(portString) ?? 7317
                     connectionManager.saveAndConnect()
                 }
                 .buttonStyle(.borderedProminent)


### PR DESCRIPTION
## Summary

9 UX issues fixed in one cohesive batch — all related to card, header, and detail view polish.

## Fixes

**#4 — Cost shows $0.00**
Hidden when zero or sub-cent. $0.00 implies free, not untracked. Now only shown when cost.sessionTotal > 0.001.

**#5 — Sub-agent labels all 'sub-agent'**
Status dot now uses green=active, grey=idle/done, red=error. Idle sub-agents show 'done' instead of a confusing duration like '1004s'.

**#7 — Nudge button is a broken promise**
Removed entirely. A permanently disabled button with no explanation is worse than no button. Will return in v1.1 when Gateway routing exists.

**#8 — Header redundancy: 'Mac mini — OpenClaws-Mac-mini'**
Removed hardcoded 'Mac mini' prefix. Header now shows hostname only. Falls back to 'OpenClaw' if hostname unavailable.

**#9 + #15 — Duration on idle agents (45h, 15h)**
Duration row only shown for active agents with durationSeconds > 0. Idle agents show 'Last active X ago' — not a meaningless stale duration.

**#10 — Wrong port default (3917 vs 7317)**
Corrected in SettingsView, ConnectionManager, and GatewayService. OpenClaw Gateway runs on 7317.

**#12 — 'Last beat' jargon**
Replaced with 'Updated X ago' — plain language, no internal infrastructure terms.

**#13 — Role in parentheses is weak design**
Role now shown as small caption below agent name — clean hierarchy, no parentheses.

**#14 — 'Normal' health label adds no value**
Hidden when health is normal. 'Taking a while' and 'Stuck' still shown — silence is the signal when healthy.