### PR TITLE
fix: low polish — right-click menu, reactive icon, deep link, animation (#6,#16,#17,#18,#19,#20)

### DIFF
--- a/ClawView/ClawView/ClawViewApp.swift
+++ b/ClawView/ClawView/ClawViewApp.swift
@@ -1,0 +1,229 @@
+import SwiftUI
+import AppKit
+import ServiceManagement
+import Combine
+
+// MARK: - App Entry Point
+
+@main
+struct ClawViewApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        // No main window — this is a menu bar app
+        Settings {
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - App Delegate
+
+@MainActor
+class AppDelegate: NSObject, NSApplicationDelegate {
+    var statusItem: NSStatusItem?
+    var popover: NSPopover?
+    var eventMonitor: Any?
+
+    let gateway = GatewayService.shared
+    let connectionManager = ConnectionManager()
+    let iconController = MenuBarIconController()
+
+    // Reactive icon updates via Combine — replaces 2s polling timer (#16)
+    private var iconCancellable: AnyCancellable?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Hide from Dock (menu bar only app)
+        NSApp.setActivationPolicy(.accessory)
+
+        setupMenuBar()
+        setupPopover()
+        startServices()
+        setupIconObserver()
+    }
+
+    // MARK: - Menu Bar Setup
+
+    func setupMenuBar() {
+        iconController.setup()
+
+        guard let statusItem = iconController.statusItem else { return }
+        self.statusItem = statusItem
+
+        guard let button = statusItem.button else { return }
+        button.action = #selector(handleStatusItemClick)
+        button.target = self
+        // Left click opens popover; right click shows context menu (#20)
+        button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+
+        // Enable layer for Core Animation
+        button.wantsLayer = true
+    }
+
+    // MARK: - Popover Setup
+
+    func setupPopover() {
+        let popover = NSPopover()
+        popover.contentSize = NSSize(width: 320, height: 400)
+        popover.behavior = .transient
+        popover.animates = true
+
+        let popoverView = PopoverView(
+            gateway: gateway,
+            connectionManager: connectionManager
+        )
+        popover.contentViewController = NSHostingController(rootView: popoverView)
+        self.popover = popover
+
+        // Close popover when clicking outside
+        eventMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.closePopover()
+            }
+        }
+    }
+
+    // MARK: - Click Handler
+
+    @objc func handleStatusItemClick() {
+        let event = NSApp.currentEvent
+        if event?.type == .rightMouseUp {
+            // Right click → context menu (#20)
+            showContextMenu()
+        } else {
+            // Left click → toggle popover
+            togglePopover()
+        }
+    }
+
+    // MARK: - Context Menu (#20, #6, #19)
+
+    private func showContextMenu() {
+        let menu = NSMenu()
+
+        // Version info (#19) — immediately visible without digging into settings
+        let versionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.1"
+        let buildString = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+        let versionLabel = buildString.isEmpty ? "ClawView v\(versionString)" : "ClawView v\(versionString) (\(buildString))"
+        let versionItem = NSMenuItem(title: versionLabel, action: nil, keyEquivalent: "")
+        versionItem.isEnabled = false
+        menu.addItem(versionItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        // Open ClawView popover
+        menu.addItem(withTitle: "Open ClawView", action: #selector(togglePopover), keyEquivalent: "")
+
+        // Open Clawdia's Discord channel directly (#17 — useful deep link)
+        let discordItem = NSMenuItem(title: "Open Clawdia in Discord", action: #selector(openClawdiaChannel), keyEquivalent: "")
+        menu.addItem(discordItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        // Quit (#20 — no dock icon means no other way to quit)
+        menu.addItem(withTitle: "Quit ClawView", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+
+        // Show menu at status item
+        statusItem?.menu = menu
+        statusItem?.button?.performClick(nil)
+        // Remove menu after showing so left-click still opens popover
+        DispatchQueue.main.async { [weak self] in
+            self?.statusItem?.menu = nil
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc func togglePopover() {
+        if let popover = popover, popover.isShown {
+            closePopover()
+        } else {
+            openPopover()
+        }
+    }
+
+    /// Open Clawdia's Discord channel directly (#17)
+    @objc func openClawdiaChannel() {
+        // Deep link to Clawdia's Discord channel
+        // Format: discord://discord.com/channels/{guild_id}/{channel_id}
+        let clawdiaChannelId = "1480700058067533886"
+        let guildId = "1480268359474126998"
+        if let url = URL(string: "discord://discord.com/channels/\(guildId)/\(clawdiaChannelId)") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    func openPopover() {
+        guard let button = statusItem?.button,
+              let popover = popover else { return }
+
+        // Recalculate content height based on agent count
+        updatePopoverSize()
+
+        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func closePopover() {
+        popover?.performClose(nil)
+    }
+
+    private func updatePopoverSize() {
+        let agentCount = gateway.allAgents.count
+        let cardHeight = 80 // approx per card
+        let headerHeight = 56
+        let footerHeight = 44
+        let bodyHeight = max(100, min(agentCount * cardHeight + 16, 392))
+        let totalHeight = headerHeight + bodyHeight + footerHeight
+        popover?.contentSize = NSSize(width: 320, height: totalHeight)
+    }
+
+    // MARK: - Reactive Icon Updates (#16)
+    // Replace 2-second polling timer with Combine subscription.
+    // Icon updates when gateway publishes new data — not on an arbitrary clock.
+
+    func setupIconObserver() {
+        iconCancellable = gateway.$systemStatus
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                self.iconController.updateFromGateway(self.gateway)
+            }
+    }
+
+    // MARK: - Services
+
+    func startServices() {
+        if connectionManager.isFirstRun {
+            // First run — show popover with setup screen
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                self.openPopover()
+            }
+        } else {
+            connectionManager.reconnect()
+        }
+    }
+
+    // MARK: - Launch at Login
+
+    func enableLaunchAtLogin() {
+        if #available(macOS 13.0, *) {
+            try? SMAppService.mainApp.register()
+        }
+    }
+
+    func disableLaunchAtLogin() {
+        if #available(macOS 13.0, *) {
+            try? SMAppService.mainApp.unregister()
+        }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        iconCancellable?.cancel()
+        gateway.disconnect()
+    }
+}

--- a/ClawView/ClawView/Views/AgentCardView.swift
+++ b/ClawView/ClawView/Views/AgentCardView.swift
@@ -247,7 +247,10 @@ struct ExpandedAgentDetail: View {
                     .fill(Color(NSColor.quaternarySystemFill))
             )
         }
-        .animation(.easeOut(duration: 0.2).delay(0.05), value: true)
+        // Fixed: was `.animation(..., value: true)` — constant never changes so animation never fires (#18)
+        // Now driven by the parent's isExpanded toggle, which passes through via re-render.
+        // The transition on the `if isExpanded` block in AgentCardView handles the actual animation.
+        // This modifier is removed to avoid the dead animation conflicting with the spring transition.
     }
 
     @ViewBuilder

--- a/ClawView/ClawView/Views/PopoverView.swift
+++ b/ClawView/ClawView/Views/PopoverView.swift
@@ -214,21 +214,17 @@ struct PopoverFooterView: View {
             Divider()
 
             HStack {
+                // Discord button — deep links to Clawdia's channel, not just open Discord (#17)
                 FooterButton(
-                    label: "Discord",
+                    label: "Clawdia",
                     icon: "arrow.up.forward.square",
                     enabled: gateway.connectionState != .disconnected
                 ) {
-                    openDiscord()
+                    openClawdiaChannel()
                 }
 
-                FooterButton(
-                    label: "Processes",
-                    icon: "list.bullet.rectangle",
-                    enabled: false // v1.1
-                ) {
-                    // Future: process viewer
-                }
+                // "Processes" removed — permanently disabled button is a broken promise (#6)
+                // Will return when process viewer is implemented in v1.1
 
                 FooterButton(
                     label: "Settings",
@@ -242,8 +238,11 @@ struct PopoverFooterView: View {
         }
     }
 
-    private func openDiscord() {
-        if let url = URL(string: "discord://") {
+    /// Deep link to Clawdia's Discord channel (#17)
+    private func openClawdiaChannel() {
+        let clawdiaChannelId = "1480700058067533886"
+        let guildId = "1480268359474126998"
+        if let url = URL(string: "discord://discord.com/channels/\(guildId)/\(clawdiaChannelId)") {
             NSWorkspace.shared.open(url)
         }
     }


### PR DESCRIPTION
## Summary

Final batch — low-severity polish items and one important architectural fix.

## Fixes

**#6 — Processes button disabled**
Removed. Dead buttons don't belong in limited menu bar real estate. Will return when process viewer ships.

**#16 — Icon polls every 2 seconds on main thread**
Replaced `iconUpdateTimer` (2s Timer) with a Combine `sink` on `gateway.$systemStatus`. Icon now updates reactively when gateway data changes — zero polling overhead.

**#17 — Discord button opens Discord to nowhere**
Renamed to 'Clawdia'. Now deep-links to Clawdia's Discord channel (`discord://discord.com/channels/{guild}/{channel}`). Same deep link used in right-click context menu.

**#18 — Animation fires on `value: true` constant**
Removed the `.animation(..., value: true)` modifier. Constant value never changes → animation never fires after first render. The expand/collapse transition is handled by the parent `if isExpanded` block's `.transition()` modifier, which works correctly.

**#19 — Version buried in settings**
Version string now appears in the right-click context menu immediately (no navigation required).

**#20 — No right-click context menu**
Added context menu on right-click with: version label, Open ClawView, Open Clawdia in Discord, Quit ClawView. Left-click still toggles popover. Uses `statusItem?.menu` pattern with auto-clear to preserve left-click behaviour.