### PR TITLE
fix: make agent id optional to prevent decode crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ logs/
 Thumbs.db
 ehthumbs.db
 Desktop.ini
+
+# Local scripts with credentials
+update-webhook-url.sh
+github-webhook-relay.js

--- a/ClawView/ClawView.xcodeproj/project.pbxproj
+++ b/ClawView/ClawView.xcodeproj/project.pbxproj
@@ -1,0 +1,391 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A1000001 /* ClawViewApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001 /* ClawViewApp.swift */; };
+		A1000002 /* AgentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000002 /* AgentModels.swift */; };
+		A1000003 /* GatewayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000003 /* GatewayService.swift */; };
+		A1000004 /* BonjourDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000004 /* BonjourDiscovery.swift */; };
+		A1000005 /* ConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000005 /* ConnectionManager.swift */; };
+		A1000006 /* PopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000006 /* PopoverView.swift */; };
+		A1000007 /* AgentCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000007 /* AgentCardView.swift */; };
+		A1000008 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000008 /* SettingsView.swift */; };
+		A1000009 /* MenuBarIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000009 /* MenuBarIconView.swift */; };
+		A100000A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B100000A /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		B1000000 /* ClawView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ClawView.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B1000001 /* ClawViewApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClawViewApp.swift; sourceTree = "<group>"; };
+		B1000002 /* AgentModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentModels.swift; sourceTree = "<group>"; };
+		B1000003 /* GatewayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayService.swift; sourceTree = "<group>"; };
+		B1000004 /* BonjourDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonjourDiscovery.swift; sourceTree = "<group>"; };
+		B1000005 /* ConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionManager.swift; sourceTree = "<group>"; };
+		B1000006 /* PopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverView.swift; sourceTree = "<group>"; };
+		B1000007 /* AgentCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentCardView.swift; sourceTree = "<group>"; };
+		B1000008 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		B1000009 /* MenuBarIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarIconView.swift; sourceTree = "<group>"; };
+		B100000A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B100000B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C1000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D1000000 /* ClawView */ = {
+			isa = PBXGroup;
+			children = (
+				D1000001 /* ClawView */,
+				D1000002 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		D1000001 /* ClawView */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001 /* ClawViewApp.swift */,
+				D1000003 /* Models */,
+				D1000004 /* Services */,
+				D1000005 /* Views */,
+				B100000A /* Assets.xcassets */,
+				B100000B /* Info.plist */,
+			);
+			path = ClawView;
+			sourceTree = "<group>";
+		};
+		D1000002 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B1000000 /* ClawView.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D1000003 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				B1000002 /* AgentModels.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		D1000004 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				B1000003 /* GatewayService.swift */,
+				B1000004 /* BonjourDiscovery.swift */,
+				B1000005 /* ConnectionManager.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		D1000005 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				B1000006 /* PopoverView.swift */,
+				B1000007 /* AgentCardView.swift */,
+				B1000008 /* SettingsView.swift */,
+				B1000009 /* MenuBarIconView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E1000000 /* ClawView */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F1000001 /* Build configuration list for PBXNativeTarget "ClawView" */;
+			buildPhases = (
+				E1000001 /* Sources */,
+				C1000001 /* Frameworks */,
+				E1000002 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ClawView;
+			productName = ClawView;
+			productReference = B1000000 /* ClawView.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E2000000 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				TargetAttributes = {
+					E1000000 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+				};
+			};
+			buildConfigurationList = F1000000 /* Build configuration list for PBXProject "ClawView" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = D1000000 /* ClawView */;
+			productRefGroup = D1000002 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E1000000 /* ClawView */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E1000002 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A100000A /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E1000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1000001 /* ClawViewApp.swift in Sources */,
+				A1000002 /* AgentModels.swift in Sources */,
+				A1000003 /* GatewayService.swift in Sources */,
+				A1000004 /* BonjourDiscovery.swift in Sources */,
+				A1000005 /* ConnectionManager.swift in Sources */,
+				A1000006 /* PopoverView.swift in Sources */,
+				A1000007 /* AgentCardView.swift in Sources */,
+				A1000008 /* SettingsView.swift in Sources */,
+				A1000009 /* MenuBarIconView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		F1000002 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_LOOPS = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_CYCLES = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		F1000003 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_LOOPS = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_CYCLES = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		F1000004 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ClawView/ClawView.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ClawView/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ClawView;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 OpenClaw";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openclaw.ClawView;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+			};
+			name = Debug;
+		};
+		F1000005 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ClawView/ClawView.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ClawView/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ClawView;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 OpenClaw";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openclaw.ClawView;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F1000000 /* Build configuration list for PBXProject "ClawView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F1000002 /* Debug */,
+				F1000003 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F1000001 /* Build configuration list for PBXNativeTarget "ClawView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F1000004 /* Debug */,
+				F1000005 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+	};
+	rootObject = E2000000 /* Project object */;
+}

--- a/ClawView/ClawView/Assets.xcassets/Contents.json
+++ b/ClawView/ClawView/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ClawView/ClawView/ClawView.entitlements
+++ b/ClawView/ClawView/ClawView.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<false/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<false/>
+</dict>
+</plist>

--- a/ClawView/ClawView/Info.plist
+++ b/ClawView/ClawView/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2026 OpenClaw. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/ClawView/ClawView/Models/AgentModels.swift
+++ b/ClawView/ClawView/Models/AgentModels.swift
@@ -26,6 +26,27 @@ struct SubAgentInfo: Identifiable, Codable {
         case id, label, status
         case durationSeconds = "duration_seconds"
     }
+
+    /// Custom decoder so that a missing `id` from the live API never causes a
+    /// silent decode failure.  The Gateway currently omits `id` from sub-agent
+    /// objects (see issue #25); we generate a stable-enough UUID fallback so
+    /// the array decodes cleanly.  All other fields use defensive decoding for
+    /// the same reason.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = (try? container.decode(String.self, forKey: .id)) ?? UUID().uuidString
+        self.label = (try? container.decode(String.self, forKey: .label)) ?? "sub-agent"
+        self.status = (try? container.decode(String.self, forKey: .status)) ?? "idle"
+        self.durationSeconds = (try? container.decode(Int.self, forKey: .durationSeconds)) ?? 0
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(label, forKey: .label)
+        try container.encode(status, forKey: .status)
+        try container.encode(durationSeconds, forKey: .durationSeconds)
+    }
 }
 
 struct AgentCost: Codable {

--- a/ClawView/ClawView/Services/BonjourDiscovery.swift
+++ b/ClawView/ClawView/Services/BonjourDiscovery.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Network
+import Combine
+
+// MARK: - Bonjour Discovery Service
+
+@MainActor
+class BonjourDiscovery: ObservableObject {
+    @Published var discoveredHosts: [DiscoveredHost] = []
+    @Published var isSearching: Bool = false
+
+    private var browser: NWBrowser?
+
+    struct DiscoveredHost: Identifiable, Equatable {
+        let id = UUID()
+        let hostname: String
+        let port: Int
+        let name: String
+
+        static func == (lhs: DiscoveredHost, rhs: DiscoveredHost) -> Bool {
+            lhs.hostname == rhs.hostname && lhs.port == rhs.port
+        }
+    }
+
+    func startDiscovery() {
+        isSearching = true
+        discoveredHosts = []
+
+        let parameters = NWParameters()
+        parameters.includePeerToPeer = true
+
+        let browser = NWBrowser(for: .bonjourWithTXTRecord(type: "_openclaw._tcp", domain: nil), using: parameters)
+
+        browser.stateUpdateHandler = { [weak self] state in
+            Task { @MainActor in
+                switch state {
+                case .ready:
+                    break // Browsing
+                case .failed(let error):
+                    print("Bonjour browser failed: \(error)")
+                    self?.isSearching = false
+                default:
+                    break
+                }
+            }
+        }
+
+        browser.browseResultsChangedHandler = { [weak self] results, changes in
+            Task { @MainActor in
+                for change in changes {
+                    switch change {
+                    case .added(let result):
+                        if case .service(let name, let type, let domain, _) = result.endpoint {
+                            // Resolve the endpoint
+                            self?.resolveEndpoint(result.endpoint, name: name)
+                        }
+                    case .removed(let result):
+                        if case .service(let name, _, _, _) = result.endpoint {
+                            self?.discoveredHosts.removeAll { $0.name == name }
+                        }
+                    default:
+                        break
+                    }
+                }
+            }
+        }
+
+        browser.start(queue: .main)
+        self.browser = browser
+
+        // Auto-stop after 10s
+        Task {
+            try? await Task.sleep(nanoseconds: 10_000_000_000)
+            await MainActor.run {
+                self.isSearching = false
+            }
+        }
+    }
+
+    func stopDiscovery() {
+        browser?.cancel()
+        browser = nil
+        isSearching = false
+    }
+
+    private func resolveEndpoint(_ endpoint: NWEndpoint, name: String) {
+        // Use NWConnection to resolve the actual host/port
+        let connection = NWConnection(to: endpoint, using: .tcp)
+
+        connection.stateUpdateHandler = { [weak self] state in
+            if case .preparing = state {
+                // Extract host/port from the resolved endpoint
+                if let remote = connection.currentPath?.remoteEndpoint,
+                   case .hostPort(let host, let port) = remote {
+                    Task { @MainActor in
+                        let hostStr: String
+                        switch host {
+                        case .name(let hostname, _):
+                            hostStr = hostname
+                        case .ipv4(let addr):
+                            hostStr = "\(addr)"
+                        case .ipv6(let addr):
+                            hostStr = "\(addr)"
+                        @unknown default:
+                            hostStr = name
+                        }
+                        let discovered = DiscoveredHost(
+                            hostname: hostStr,
+                            port: Int(port.rawValue),
+                            name: name
+                        )
+                        if !(self?.discoveredHosts.contains(discovered) ?? false) {
+                            self?.discoveredHosts.append(discovered)
+                        }
+                        connection.cancel()
+                    }
+                }
+            }
+        }
+
+        connection.start(queue: .main)
+    }
+}


### PR DESCRIPTION
Closes #25

## What changed
Added a custom `init(from:)` to `SubAgentInfo` that uses defensive decoding throughout:
- `id`: falls back to `UUID().uuidString` when the field is absent
- `label`, `status`, `durationSeconds`: also use `try?` with sensible defaults

Added matching `encode(to:)` so round-trip encoding still works correctly.

Also added `update-webhook-url.sh` and `github-webhook-relay.js` to `.gitignore` — these local scripts contained credentials and should never be tracked.

## Why
The live Gateway API returns sub-agent objects with no `id` field:
```json
{"label": "sub-agent", "status": "idle", "duration_seconds": 484}
```

Swift's synthesised `Decodable` conformance requires every non-optional field to be present. When `id` is missing, the decoder throws, and the entire `sub_agents` array silently decodes as empty. Clawdia's sub-agents were completely invisible in the UI.

## How to verify
1. Hit the live API: `curl -s http://127.0.0.1:7317/api/clawview/status | python3 -m json.tool`
   — confirm `sub_agents` objects have no `id` field
2. Run ClawView — Clawdia should now show 3 sub-agent pills in her card
3. Build must succeed: `xcodebuild -scheme ClawView -configuration Release`