### PR TITLE
fix: add stale data warning banner when gateway unreachable > 5m

### DIFF
--- a/ClawView/ClawView/Views/PopoverView.swift
+++ b/ClawView/ClawView/Views/PopoverView.swift
@@ -82,6 +82,23 @@ struct PopoverHeaderView: View {
             .padding(.vertical, 12)
             .frame(height: 56)
 
+            // Stale data warning banner (#43) — shown when no gateway response for > 5 minutes.
+            // heartbeatIsStale is a computed var on GatewayService (> 300s).
+            if gateway.heartbeatIsStale {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("Data may be outdated — last updated \(heartbeatAge) ago")
+                        .font(.caption2)
+                        .lineLimit(1)
+                }
+                .foregroundColor(Color(NSColor.systemYellow))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 5)
+                .background(Color(NSColor.systemYellow).opacity(0.12))
+            }
+
             Divider()
         }
         .onReceive(timer) { _ in


### PR DESCRIPTION
Closes #43

## What changed
Added a stale data warning banner to `PopoverHeaderView`. When `gateway.heartbeatIsStale` is true (no response in > 300 seconds), a yellow banner appears between the header row and the divider:

```
⚠️  Data may be outdated — last updated 8m ago
```

The banner:
- Uses `exclamationmark.triangle.fill` system icon
- `NSColor.systemYellow` for text and icon, at 0.12 opacity for the background tint
- `heartbeatAge` in the banner text so the user sees exactly how stale the data is
- `frame(maxWidth: .infinity)` so it spans the full header width (hard to miss)
- Disappears automatically when gateway reconnects (`heartbeatIsStale` becomes false)

## Why
The previous UI only showed a small yellow "Updated 8m ago" text in the top-right corner. If you weren't looking for it, you'd never notice. Agent cards continued to look fully live while showing minutes-old data. This banner is impossible to miss.

`heartbeatIsStale` was already implemented on `GatewayService` but never consumed by any view.

## How to verify
1. Stop the Gateway: `openclaw gateway stop`
2. Wait 5+ minutes
3. Open ClawView — the yellow warning banner should appear below the hostname
4. Restart gateway: `openclaw gateway start`
5. Within 5 seconds, the banner should disappear