### PR TITLE
fix: filter and normalise low-quality activity text in recent activity feed

### DIFF
--- a/ClawView/ClawView/Models/AgentModels.swift
+++ b/ClawView/ClawView/Models/AgentModels.swift
@@ -99,6 +99,47 @@ struct RecentActivityEntry: Identifiable, Codable {
         formatter.dateFormat = "HH:mm"
         return formatter.string(from: time)
     }
+
+    /// Returns a display-quality version of the activity text, or `nil` if the
+    /// entry is pure noise and should be filtered out entirely (#26).
+    ///
+    /// Noise entries (filtered out — return nil):
+    ///   "Running sleep", "Running which", "Running ls", "Running cat",
+    ///   "Running echo", "Running pwd", "Running cd", "Running true",
+    ///   "Running false", "Working..." (Gateway's own placeholder)
+    ///
+    /// Low-signal entries (normalised to "Working…"):
+    ///   "Running command" (no further context)
+    ///
+    /// Everything else passes through unchanged.
+    var cleanedText: String? {
+        let t = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Pure noise — filter out entirely
+        let noisePatterns: [String] = [
+            "Running sleep",
+            "Running which",
+            "Running ls",
+            "Running cat",
+            "Running echo",
+            "Running pwd",
+            "Running cd",
+            "Running true",
+            "Running false",
+            "Working...",   // Gateway's own low-quality placeholder
+        ]
+        for noise in noisePatterns {
+            if t.caseInsensitiveCompare(noise) == .orderedSame { return nil }
+        }
+
+        // Low-signal — normalise to ellipsis variant
+        if t.caseInsensitiveCompare("Running command") == .orderedSame {
+            return "Working…"
+        }
+
+        // Everything else is fine
+        return t.isEmpty ? nil : t
+    }
 }
 
 struct AgentInfo: Identifiable, Codable {
@@ -170,6 +211,21 @@ struct AgentInfo: Identifiable, Codable {
 
     // Computed helper
     var isActive: Bool { status == "active" }
+
+    /// Filters and normalises the raw `recentActivity` entries for display (#26).
+    ///
+    /// The Gateway emits low-quality activity strings like "Running command",
+    /// "Running sleep", and "Running which" that give the user zero information.
+    /// This property:
+    ///   1. Strips pure noise entries (sleep, bare shell builtins, "Working...")
+    ///   2. Normalises remaining low-quality strings to "Working…"
+    ///   3. Preserves high-signal entries unchanged (file names, service names, etc.)
+    var filteredRecentActivity: [RecentActivityEntry] {
+        recentActivity.compactMap { entry in
+            let cleaned = entry.cleanedText
+            return cleaned == nil ? nil : entry
+        }
+    }
 }
 
 struct SystemStatus: Codable {

--- a/ClawView/ClawView/Views/AgentCardView.swift
+++ b/ClawView/ClawView/Views/AgentCardView.swift
@@ -168,19 +168,20 @@ struct ExpandedAgentDetail: View {
                     sectionHeader("RECENT ACTIVITY")
                     Divider()
 
-                    if agent.recentActivity.isEmpty {
+                    if agent.filteredRecentActivity.isEmpty {
                         Text("No recent activity")
                             .font(.caption)
                             .foregroundColor(Color(NSColor.tertiaryLabelColor))
                     } else {
-                        ForEach(agent.recentActivity.suffix(8)) { entry in
+                        ForEach(agent.filteredRecentActivity.suffix(8)) { entry in
                             HStack(alignment: .top, spacing: 8) {
                                 Text(entry.formattedTime)
                                     .font(.system(.caption, design: .monospaced))
                                     .foregroundColor(Color(NSColor.tertiaryLabelColor))
                                     .frame(width: 40, alignment: .leading)
 
-                                Text(entry.text)
+                                // cleanedText is non-nil for every entry in filteredRecentActivity
+                                Text(entry.cleanedText ?? entry.text)
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                                     .lineLimit(2)


### PR DESCRIPTION
Closes #26

## What changed

Two additions to `AgentModels.swift`:

1. **`RecentActivityEntry.cleanedText`** — computed property that returns `nil` (filter out) or a normalised string:
   - Noise entries → `nil` (removed from display): `"Running sleep"`, `"Running which"`, `"Running ls"`, `"Running cat"`, `"Running echo"`, `"Running pwd"`, `"Running cd"`, `"Running true"`, `"Running false"`, `"Working..."`
   - `"Running command"` (bare, no context) → `"Working…"`
   - Everything with real signal (file names, service names, verb phrases) → unchanged

2. **`AgentInfo.filteredRecentActivity`** — computed property that strips entries where `cleanedText` is `nil`. Used instead of `recentActivity` in the view.

`AgentCardView.swift` updated to use `filteredRecentActivity` and render `entry.cleanedText ?? entry.text`.

## Why

The Gateway emits raw tool labels. Prawn's feed was showing four consecutive "Running command" entries — telling Jack nothing. "Running sleep" is pure noise. This is a client-side quality filter so the UI shows only entries worth reading.

The raw `recentActivity` array is preserved on the model — the filter only applies at display time, so API improvements will flow through automatically.

## How to verify

Prawn's recent activity panel (Prawn was last active 13h ago) should now show:
- "Searching files" ✅ (kept)
- "Editing ultravox-server.js" ✅ (kept, twice — good signal)
- No "Running command" entries
- No "Running sleep" entries