### PR TITLE
fix: use ordinal sub-agent labels when Gateway emits generic 'sub-agent'

### DIFF
--- a/ClawView/ClawView/Views/AgentCardView.swift
+++ b/ClawView/ClawView/Views/AgentCardView.swift
@@ -196,15 +196,28 @@ struct ExpandedAgentDetail: View {
                         sectionHeader("SUB-AGENTS")
                         Divider()
 
-                        ForEach(agent.subAgents) { sub in
+                        ForEach(Array(agent.subAgents.enumerated()), id: \.element.id) { index, sub in
                             HStack(spacing: 6) {
                                 // Dot colour reflects actual status — not hardcoded green (#5)
                                 Circle()
                                     .fill(subAgentStatusColor(sub.status))
                                     .frame(width: 6, height: 6)
 
-                                // Label with fallback for generic "sub-agent" entries (#5)
-                                Text(sub.label == "sub-agent" ? "Sub-agent" : sub.label)
+                                // Label: use API label if it has real content; otherwise
+                                // fall back to "Sub-agent N" with ordinal (#27).
+                                // The ordinal makes multiple anonymous sub-agents distinguishable
+                                // until the Gateway emits task-derived labels.
+                                let displayLabel: String = {
+                                    let raw = sub.label.trimmingCharacters(in: .whitespacesAndNewlines)
+                                    let isGeneric = raw.isEmpty || raw.lowercased() == "sub-agent"
+                                    if isGeneric {
+                                        return "Sub-agent \(index + 1)"
+                                    }
+                                    // Capitalise first letter for display consistency
+                                    return raw.prefix(1).uppercased() + raw.dropFirst()
+                                }()
+
+                                Text(displayLabel)
                                     .font(.caption)
                                     .foregroundColor(.secondary)
 


### PR DESCRIPTION
Closes #27

## What changed

Updated the sub-agents `ForEach` in `AgentCardView` to use `enumerated()` and generate ordinal labels ("Sub-agent 1", "Sub-agent 2", etc.) when the Gateway emits the generic `"sub-agent"` string.

Logic:
- If label is empty or `"sub-agent"` (case-insensitive) → display "Sub-agent N" where N is 1-based index
- If label has real content → capitalise first letter and display as-is
- This preserves future compatibility when the Gateway emits task-derived labels

## Why

Issue #5 was closed but only capitalised the fallback to "Sub-agent". When Clawdia has 4 simultaneous sub-agents, they all show as "Sub-agent (done)" — indistinguishable. Ordinal numbering gives at least enough signal to track that there are 4 distinct agents and which one is still running.

**Note:** This is a client-side best-effort fix. The underlying data quality issue (Gateway emitting `"label": "sub-agent"` for every sub-agent instead of task-derived labels) requires Gateway changes. Filed separately. This PR makes the UI as good as it can be given the current data.

## How to verify

Open ClawView when Clawdia has sub-agents running. Instead of multiple identical "Sub-agent" rows, you should see "Sub-agent 1", "Sub-agent 2", etc.