### PR TITLE
fix: add exponential backoff to polling on consecutive failures

### DIFF
--- a/ClawView/ClawView/Services/GatewayService.swift
+++ b/ClawView/ClawView/Services/GatewayService.swift
@@ -64,19 +64,35 @@ class GatewayService: ObservableObject {
     func startPolling() {
         pollingTask?.cancel()
         pollingTask = Task {
+            // Exponential backoff on consecutive failures (#29).
+            // Base interval: 5s. Doubles per failure up to a 120s cap.
+            // Resets to 5s immediately on success.
+            var consecutiveFailures = 0
             while !Task.isCancelled {
-                await fetchStatus()
-                try? await Task.sleep(nanoseconds: 5_000_000_000) // 5s poll
+                let success = await fetchStatus()
+                if success {
+                    consecutiveFailures = 0
+                } else {
+                    consecutiveFailures += 1
+                }
+                // delay = 5s * 2^(failures-1), capped at 120s, minimum 5s
+                let delay = consecutiveFailures == 0
+                    ? 5.0
+                    : min(5.0 * pow(2.0, Double(consecutiveFailures - 1)), 120.0)
+                let delayNs = UInt64(delay * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: delayNs)
             }
         }
     }
 
     // MARK: - API Calls
 
-    func fetchStatus() async {
+    /// Fetches the current gateway status. Returns `true` on success, `false` on any failure.
+    @discardableResult
+    func fetchStatus() async -> Bool {
         guard !host.isEmpty else {
             connectionState = .disconnected
-            return
+            return false
         }
 
         // Try the dedicated /api/clawview/status endpoint first
@@ -87,6 +103,7 @@ class GatewayService: ObservableObject {
             lastHeartbeat = Date()
             connectionState = .localNetwork
             errorMessage = nil
+            return true
         } catch {
             // Try fallback
             do {
@@ -95,9 +112,11 @@ class GatewayService: ObservableObject {
                 lastHeartbeat = Date()
                 connectionState = .localNetwork
                 errorMessage = nil
+                return true
             } catch {
                 connectionState = .disconnected
                 errorMessage = error.localizedDescription
+                return false
             }
         }
     }


### PR DESCRIPTION
Closes #29

## What changed

`startPolling()` in `GatewayService.swift` now tracks consecutive failures and applies exponential backoff:

- 0 failures (normal): 5s
- 1st failure: 5s
- 2nd failure: 10s
- 3rd failure: 20s
- 4th failure: 40s
- 5th+ failure: 80s → capped at 120s
- On success: reset to 5s immediately

`fetchStatus()` signature changed from `async -> Void` to `async -> Bool` and marked `@discardableResult` so existing call sites that ignore the return value continue to compile without changes.

Formula: `delay = 5s × 2^(consecutiveFailures - 1)`, capped at 120s, minimum 5s.

## Why

When the gateway is unreachable, the old code retried every 5s indefinitely — 12 requests/minute forever. If Jack's Mac mini is off while he's travelling, ClawView was draining battery and spamming failed network requests with zero benefit.

With backoff, after ~5 consecutive failures the retry interval is 120s (2 req/min). The UI already shows the stale data warning (PR #45), so Jack knows something is wrong.

## How to verify

1. Stop the Gateway: `openclaw gateway stop`
2. Watch the xcode console or add a print — poll intervals should increase: 5s, 5s, 10s, 20s, 40s, 80s, 120s, 120s...
3. Restart the Gateway — next successful fetch resets the counter to 0 and polling returns to 5s