### PR TITLE
fix: configure URLSession with 8s request timeout to prevent hanging polls

### DIFF
--- a/ClawView/ClawView/Services/GatewayService.swift
+++ b/ClawView/ClawView/Services/GatewayService.swift
@@ -36,7 +36,16 @@ class GatewayService: ObservableObject {
 
     private var pollingTask: Task<Void, Never>?
     private var webSocketTask: URLSessionWebSocketTask?
-    private var urlSession = URLSession.shared
+    /// Custom URLSession with tight timeouts (#30).
+    /// Default URLSession.shared allows 60s per request — far too long for a
+    /// local/LAN gateway poll. 8s request timeout means a hung gateway surfaces
+    /// as a disconnect within one poll cycle, not after a 60s freeze.
+    private var urlSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 8   // per-request: gateway must start responding within 8s
+        config.timeoutIntervalForResource = 10 // total resource load: 10s hard cap
+        return URLSession(configuration: config)
+    }()
 
     // Connection config
     private(set) var host: String = ""


### PR DESCRIPTION
Closes #30

## What changed

Replaced `URLSession.shared` with a custom `URLSession` configured with tight timeouts:

```swift
private var urlSession: URLSession = {
    let config = URLSessionConfiguration.default
    config.timeoutIntervalForRequest = 8   // gateway must start responding within 8s
    config.timeoutIntervalForResource = 10 // hard cap on total response time
    return URLSession(configuration: config)
}()
```

## Why

`URLSession.shared` has a default `timeoutIntervalForRequest` of 60 seconds. If the gateway hangs (e.g. SSH tunnel stalled, process frozen), the polling task would block for up to 60s per request. During that time the UI shows stale data with the "Updated Xs ago" counter ticking up and no explanation.

8 seconds is generous for a local/LAN request (which should respond in <100ms normally) but tolerant of SSH tunnel latency. After 8s, the request fails, `fetchStatus()` returns `false`, and the backoff logic from PR #48 kicks in.

The two fixes work together: timeout fast (#30) + back off intelligently (#29).

## How to verify

1. Introduce artificial network latency or hang the Gateway
2. Previously: app blocks 60s per poll, UI frozen
3. After fix: request fails in ~8s, disconnect state shows, backoff kicks in