### PR TITLE
[Audit 2] Activity timestamps — add date context for yesterday/older entries (#32)

### DIFF
--- a/ClawView/ClawView/Models/AgentModels.swift
+++ b/ClawView/ClawView/Models/AgentModels.swift
@@ -93,11 +93,37 @@ struct RecentActivityEntry: Identifiable, Codable {
         try container.encode(text, forKey: .text)
     }
 
-    /// Human-readable "HH:mm" from the entry's timestamp
+    // MARK: - Cached formatters for formattedTime (#32)
+
+    private static let timeOnlyFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        return f
+    }()
+
+    private static let shortDateTimeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d HH:mm"
+        return f
+    }()
+
+    /// Human-readable timestamp for an activity entry (#32).
+    ///
+    /// - Same day:   "HH:mm"           (e.g. "14:32")
+    /// - Yesterday:  "Yest HH:mm"      (e.g. "Yest 18:31")
+    /// - Older:      "MMM d HH:mm"     (e.g. "Mar 10 18:31")
+    ///
+    /// Entries from previous days are now clearly distinguishable from today's
+    /// entries — Jack won't mistake yesterday's activity for something recent.
     var formattedTime: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return formatter.string(from: time)
+        let calendar = Calendar.current
+        if calendar.isDateInToday(time) {
+            return RecentActivityEntry.timeOnlyFormatter.string(from: time)
+        } else if calendar.isDateInYesterday(time) {
+            return "Yest " + RecentActivityEntry.timeOnlyFormatter.string(from: time)
+        } else {
+            return RecentActivityEntry.shortDateTimeFormatter.string(from: time)
+        }
     }
 
     /// Returns a display-quality version of the activity text, or `nil` if the

--- a/ClawView/ClawView/Views/AgentCardView.swift
+++ b/ClawView/ClawView/Views/AgentCardView.swift
@@ -199,7 +199,8 @@ struct ExpandedAgentDetail: View {
                                 Text(entry.formattedTime)
                                     .font(.system(.caption, design: .monospaced))
                                     .foregroundColor(Color(NSColor.tertiaryLabelColor))
-                                    .frame(width: 40, alignment: .leading)
+                                    // Width 72: fits "Yest HH:mm" (9 chars) and "MMM d HH:mm" (11 chars) (#32)
+                                    .frame(width: 72, alignment: .leading)
 
                                 // cleanedText is non-nil for every entry in filteredRecentActivity
                                 Text(entry.cleanedText ?? entry.text)


### PR DESCRIPTION
## What changed

Closes #32

### Problem
`RecentActivityEntry.formattedTime` returned `HH:mm` for all entries. An entry from yesterday at 18:31 and today at 18:31 were visually identical in the expanded card.

### Solution
Three-tier format in `formattedTime`:
| Entry age | Format | Example |
|---|---|---|
| Today | `HH:mm` | `14:32` |
| Yesterday | `Yest HH:mm` | `Yest 18:31` |
| Older | `MMM d HH:mm` | `Mar 10 18:31` |

Both DateFormatters are static/cached — no allocation cost per render.

Activity row time column widened from 40pt → 72pt to fit the longer formats.

### How to test
- Expand an agent card with activity entries from yesterday → times show `Yest 18:31` format
- Today's entries still show plain `HH:mm`
- Older entries show `MMM d HH:mm`
