### PR TITLE
[Audit 2] Launch at Login toggle in Settings UI (#33)

### DIFF
--- a/ClawView/ClawView/ClawViewApp.swift
+++ b/ClawView/ClawView/ClawViewApp.swift
@@ -205,19 +205,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    // MARK: - Launch at Login
-
-    func enableLaunchAtLogin() {
-        if #available(macOS 13.0, *) {
-            try? SMAppService.mainApp.register()
-        }
-    }
-
-    func disableLaunchAtLogin() {
-        if #available(macOS 13.0, *) {
-            try? SMAppService.mainApp.unregister()
-        }
-    }
+    // Launch at Login is now controlled by SettingsView directly via
+    // SMAppService.mainApp.register/unregister (#33). AppDelegate helpers removed.
 
     func applicationWillTerminate(_ notification: Notification) {
         if let monitor = eventMonitor {

--- a/ClawView/ClawView/Views/SettingsView.swift
+++ b/ClawView/ClawView/Views/SettingsView.swift
@@ -66,10 +66,16 @@ struct SettingsView: View {
                                         .fill(Color(NSColor.quaternarySystemFill))
                                 )
                                 .onChange(of: launchAtLogin) { enabled in
-                                    if enabled {
-                                        try? SMAppService.mainApp.register()
-                                    } else {
-                                        try? SMAppService.mainApp.unregister()
+                                    // If SMAppService call fails, revert toggle
+                                    // so UI doesn't show a false state (#33 Codex review)
+                                    do {
+                                        if enabled {
+                                            try SMAppService.mainApp.register()
+                                        } else {
+                                            try SMAppService.mainApp.unregister()
+                                        }
+                                    } catch {
+                                        launchAtLogin = !enabled
                                     }
                                 }
                         }


### PR DESCRIPTION
## What changed

Closes #33

### Problem
`AppDelegate` had fully-implemented `enableLaunchAtLogin()` / `disableLaunchAtLogin()` using `SMAppService`. No UI existed to call them. Every reboot required manually relaunching ClawView.

### Solution
Added a **GENERAL** section to `SettingsView` (above CONNECTION) with a "Launch at Login" toggle.

- **Read state on appear:** `SMAppService.mainApp.status == .enabled`
- **Toggle onChange:** calls `SMAppService.mainApp.register()` or `unregister()` directly
- **macOS guard:** entire GENERAL section is `#available(macOS 13.0, *)` — hidden on older OS rather than showing broken UI

### How to test
1. Open Settings
2. GENERAL section visible with "Launch at Login" toggle
3. Toggle on → system registers ClawView as login item
4. Log out / log in → ClawView launches automatically
5. Toggle off → unregistered
