### PR TITLE
[Audit 2] DisconnectedView hardcoded hostname — use configured host (#35)

### DIFF
--- a/ClawView/ClawView/Views/PopoverView.swift
+++ b/ClawView/ClawView/Views/PopoverView.swift
@@ -215,7 +215,10 @@ struct DisconnectedView: View {
                 .foregroundColor(Color(NSColor.tertiaryLabelColor))
 
             VStack(spacing: 6) {
-                Text("Can't reach your Mac mini")
+                // Use configured host rather than hardcoded "Mac mini" (#35)
+                // gateway.host is the address the user configured; empty means not yet set.
+                let hostLabel = gateway.host.isEmpty ? "OpenClaw" : gateway.host
+                Text("Can't reach \(hostLabel)")
                     .font(.headline)
                     .foregroundColor(.primary)
                     .multilineTextAlignment(.center)


### PR DESCRIPTION
## What changed

Closes #35

Same class of bug as #8 (fixed in the header), different location.

### Problem
`DisconnectedView` hardcoded `"Can't reach your Mac mini"`. Wrong for MacBook, Mac Pro, VPS, Pi, or any non-Mac-mini host.

### Solution
Use `gateway.host` (the configured address) with fallback to `"OpenClaw"` if empty:

```
Can't reach griffin.local
Can't reach 192.168.1.100
Can't reach OpenClaw  (fallback when host not yet set)
```

`gateway` is already an `@ObservedObject` on `DisconnectedView` — no extra plumbing needed.
