### PR TITLE
[Audit 2] First Run screen icon — replace pawprint.fill with lobster emoji (#34)

### DIFF
--- a/ClawView/ClawView/Views/SettingsView.swift
+++ b/ClawView/ClawView/Views/SettingsView.swift
@@ -193,10 +193,11 @@ struct FirstRunView: View {
             Divider().opacity(0)
 
             VStack(spacing: 20) {
-                // Icon — pawprint.fill placeholder until custom claw asset is ready (#1)
-                Image(systemName: "pawprint.fill")
+                // Icon — lobster emoji as interim branding (#34).
+                // pawprint.fill was never appropriate (evokes pet app).
+                // Replace with custom claw SVG asset when it ships (see icon issue #40).
+                Text("🦞")
                     .font(.system(size: 48))
-                    .foregroundColor(Color(NSColor.controlAccentColor))
                     .padding(.top, 24)
 
                 VStack(spacing: 6) {


### PR DESCRIPTION
## What changed

Closes #34

### Problem
`FirstRunView` was showing `Image(systemName: "pawprint.fill")` with a comment saying "placeholder until custom claw asset is ready (#1)". Issue #1 was closed. The placeholder was never updated. First thing a new user sees: a paw print.

### Solution
Replaced with `Text("🦞")` — same lobster emoji used throughout the app. Consistent branding, no longer evokes a pet app.

Comment updated to note that the custom claw SVG (#40) should replace this when it ships.

### How to test
- Reset to first run (delete UserDefaults `clawview_connection` key) or use Settings → clear host and save
- First Run screen shows 🦞 at 48pt, not a paw print
