### PR TITLE
[Audit 2] Mock sub-agent status 'running' → 'active' (#36)

### DIFF
--- a/ClawView/ClawView/Models/AgentModels.swift
+++ b/ClawView/ClawView/Models/AgentModels.swift
@@ -319,7 +319,7 @@ extension SystemStatus {
                     "last_activity": "2026-03-11T14:25:00Z",
                     "channel": "1480707570179117167",
                     "sub_agents": [
-                        { "id": "sub1", "label": "designer-clawview", "status": "running", "duration_seconds": 180 }
+                        { "id": "sub1", "label": "designer-clawview", "status": "active", "duration_seconds": 180 }
                     ],
                     "cost": { "session_total": 0.42 }
                 },


### PR DESCRIPTION
## What changed

Closes #36

One-character fix: mock JSON sub-agent `"status": "running"` → `"status": "active"`.

`subAgentStatusColor()` maps `"active"` to green. `"running"` hits the `default` case → gray. The mock was testing the wrong code path. In dev/mock mode, Steve's sub-agent showed a gray dot when it should show green.
