### PR TITLE
[Audit 2] Popover height magic constant — use fixed 540pt, remove updatePopoverSize() (#38)

### DIFF
--- a/ClawView/ClawView/ClawViewApp.swift
+++ b/ClawView/ClawView/ClawViewApp.swift
@@ -64,7 +64,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func setupPopover() {
         let popover = NSPopover()
-        popover.contentSize = NSSize(width: 320, height: 400)
+        // Fixed height: ScrollView with maxHeight:540 handles variable content (#38).
+        // Dynamic sizing via updatePopoverSize() was using a wrong 80pt-per-card
+        // constant, causing clips and blank space. Let SwiftUI layout win.
+        popover.contentSize = NSSize(width: 320, height: 540)
         popover.behavior = .transient
         popover.animates = true
 
@@ -157,25 +160,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard let button = statusItem?.button,
               let popover = popover else { return }
 
-        // Recalculate content height based on agent count
-        updatePopoverSize()
-
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         NSApp.activate(ignoringOtherApps: true)
     }
 
     func closePopover() {
         popover?.performClose(nil)
-    }
-
-    private func updatePopoverSize() {
-        let agentCount = gateway.allAgents.count
-        let cardHeight = 80 // approx per card
-        let headerHeight = 56
-        let footerHeight = 44
-        let bodyHeight = max(100, min(agentCount * cardHeight + 16, 392))
-        let totalHeight = headerHeight + bodyHeight + footerHeight
-        popover?.contentSize = NSSize(width: 320, height: totalHeight)
     }
 
     // MARK: - Reactive Icon Updates (#16)


### PR DESCRIPTION
## What changed

Closes #38

### Problem
`updatePopoverSize()` calculated popover height using a hardcoded `cardHeight = 80`. Cards have variable height (1 line vs 2 lines of activity, last-active row vs duration row). The estimate was wrong almost every time — popover clipped the bottom card or left blank space.

### Solution
Remove `updatePopoverSize()` entirely. Set `contentSize = NSSize(width: 320, height: 540)` once in `setupPopover()`. The `ScrollView` in `AgentListView` already has `maxHeight: 540` — it handles variable-height content correctly. SwiftUI's layout engine does a better job than integer estimation.
