### PR TITLE
fix: remove Clawdia footer button from PopoverView

### DIFF
--- a/ClawView/ClawView/Views/PopoverView.swift
+++ b/ClawView/ClawView/Views/PopoverView.swift
@@ -269,18 +269,7 @@ struct PopoverFooterView: View {
             Divider()
 
             HStack {
-                // Discord button — deep links to Clawdia's channel, not just open Discord (#17)
-                FooterButton(
-                    label: "Clawdia",
-                    icon: "arrow.up.forward.square",
-                    enabled: gateway.connectionState != .disconnected
-                ) {
-                    openClawdiaChannel()
-                }
-
-                // "Processes" removed — permanently disabled button is a broken promise (#6)
-                // Will return when process viewer is implemented in v1.1
-
+                // Clawdia Discord button removed (#68) — was failing silently
                 FooterButton(
                     label: "Settings",
                     icon: "gearshape",
@@ -290,15 +279,6 @@ struct PopoverFooterView: View {
             }
             .padding(.horizontal, 16)
             .frame(height: 44)
-        }
-    }
-
-    /// Deep link to Clawdia's Discord channel (#17)
-    private func openClawdiaChannel() {
-        let clawdiaChannelId = "1480700058067533886"
-        let guildId = "1480268359474126998"
-        if let url = URL(string: "discord://discord.com/channels/\(guildId)/\(clawdiaChannelId)") {
-            NSWorkspace.shared.open(url)
         }
     }
 }


### PR DESCRIPTION
Closes #68

## What changed

Removed the 'Clawdia' `FooterButton` from `PopoverFooterView` in `PopoverView.swift`.

The button attempted to open a Discord deep link to Clawdia's channel (`discord://discord.com/channels/...`). It was failing silently and Jack doesn't need it.

Also removed the `openClawdiaChannel()` private function — now dead code without the button.

Footer is now: Settings button only.

## What was NOT removed
- `FooterButton` struct — still used by the Settings button
- The footer itself — just simplified

## How to verify
- Open ClawView popover — footer has only the Settings button, no Clawdia button