### PR TITLE
feat: add pin button to detach popover as persistent floating panel

### DIFF
--- a/ClawView/ClawView/ClawViewApp.swift
+++ b/ClawView/ClawView/ClawViewApp.swift
@@ -25,6 +25,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var popover: NSPopover?
     var eventMonitor: Any?
 
+    /// Floating panel for the detached/pinned mode (#63).
+    var floatingPanel: NSPanel?
+    /// Tracks whether the popover is currently detached as a floating panel (#63).
+    var isPinned: Bool = false
+
     let gateway = GatewayService.shared
     let connectionManager = ConnectionManager()
     let iconController = MenuBarIconController()
@@ -73,7 +78,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let popoverView = PopoverView(
             gateway: gateway,
-            connectionManager: connectionManager
+            connectionManager: connectionManager,
+            isPinned: false,
+            onPinToggled: { [weak self] in
+                Task { @MainActor [weak self] in self?.togglePin() }
+            }
         )
         popover.contentViewController = NSHostingController(rootView: popoverView)
         self.popover = popover
@@ -166,6 +175,112 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func closePopover() {
         popover?.performClose(nil)
+    }
+
+    // MARK: - Floating Panel (Pin/Unpin) (#63)
+
+    /// Toggles between popover mode and detached floating panel mode.
+    /// Pin:   closes the popover → opens a persistent NSPanel at .floating window level
+    /// Unpin: closes the floating panel → restores normal popover/click behaviour
+    func togglePin() {
+        if isPinned {
+            unpin()
+        } else {
+            pin()
+        }
+    }
+
+    private func pin() {
+        isPinned = true
+
+        // Close the popover — we're taking over with a panel
+        popover?.performClose(nil)
+
+        // Build the panel content with isPinned=true so the pin button shows as lit
+        let pinnedView = PopoverView(
+            gateway: gateway,
+            connectionManager: connectionManager,
+            isPinned: true,
+            onPinToggled: { [weak self] in
+                Task { @MainActor [weak self] in self?.togglePin() }
+            }
+        )
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 540),
+            styleMask: [
+                .titled,
+                .closable,
+                .fullSizeContentView,
+                .nonactivatingPanel,   // doesn't steal focus from other apps
+                .utilityWindow,        // smaller title bar, stays above most windows
+            ],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.level = .floating             // above normal windows
+        panel.isFloatingPanel = true
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.backgroundColor = NSColor.windowBackgroundColor
+        panel.isReleasedWhenClosed = false
+
+        // Position: near the status item, below the menu bar
+        if let button = statusItem?.button, let screen = button.window?.screen ?? NSScreen.main {
+            let buttonRect = button.convert(button.bounds, to: nil)
+            let screenRect = button.window?.convertToScreen(buttonRect) ?? buttonRect
+            let panelX = min(screenRect.minX, screen.frame.maxX - 330)
+            let panelY = screen.frame.maxY - screen.visibleFrame.maxY + screen.visibleFrame.height - 550
+            panel.setFrameOrigin(NSPoint(x: panelX, y: panelY))
+        } else {
+            panel.center()
+        }
+
+        panel.contentViewController = NSHostingController(rootView: pinnedView)
+
+        // When the panel is closed via the close button, unpin cleanly
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: panel,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self = self, self.isPinned else { return }
+                self.isPinned = false
+                self.floatingPanel = nil
+                // Restore popover pin button to unlit state
+                self.refreshPopoverContent()
+            }
+        }
+
+        panel.orderFront(nil)
+        self.floatingPanel = panel
+    }
+
+    private func unpin() {
+        isPinned = false
+        floatingPanel?.close()
+        floatingPanel = nil
+        // Refresh popover so it reopens with isPinned=false
+        refreshPopoverContent()
+    }
+
+    /// Rebuilds the popover content view with the current isPinned state.
+    /// Called after pin state changes so the pin button reflects reality.
+    private func refreshPopoverContent() {
+        let updatedView = PopoverView(
+            gateway: gateway,
+            connectionManager: connectionManager,
+            isPinned: isPinned,
+            onPinToggled: { [weak self] in
+                Task { @MainActor [weak self] in self?.togglePin() }
+            }
+        )
+        if let vc = popover?.contentViewController as? NSHostingController<PopoverView> {
+            vc.rootView = updatedView
+        }
     }
 
     // MARK: - Reactive Icon Updates (#16)

--- a/ClawView/ClawView/Views/PopoverView.swift
+++ b/ClawView/ClawView/Views/PopoverView.swift
@@ -7,6 +7,14 @@ struct PopoverView: View {
     @ObservedObject var connectionManager: ConnectionManager
     @State private var showSettings = false
 
+    /// Whether the view is currently displayed in a floating panel (#63).
+    /// When true, the header shows a lit pin icon.
+    var isPinned: Bool = false
+
+    /// Callback invoked when the user taps the pin button (#63).
+    /// The caller (AppDelegate) handles the actual panel/popover transition.
+    var onPinToggled: (() -> Void)? = nil
+
     var body: some View {
         VStack(spacing: 0) {
             if showSettings {
@@ -27,7 +35,12 @@ struct PopoverView: View {
     private var mainContent: some View {
         VStack(spacing: 0) {
             // Header — pass connectionManager so header can read display name (#28)
-            PopoverHeaderView(gateway: gateway, connectionManager: connectionManager)
+            PopoverHeaderView(
+                gateway: gateway,
+                connectionManager: connectionManager,
+                isPinned: isPinned,
+                onPinToggled: onPinToggled
+            )
 
             // Body
             if gateway.connectionState == .disconnected {
@@ -51,6 +64,10 @@ struct PopoverHeaderView: View {
     @ObservedObject var gateway: GatewayService
     /// Connection settings, used to read the user-configured display name (#28).
     var connectionManager: ConnectionManager? = nil
+    /// Whether the view is currently in floating panel mode (#63).
+    var isPinned: Bool = false
+    /// Called when the user taps the pin button (#63).
+    var onPinToggled: (() -> Void)? = nil
     @State private var heartbeatAge: String = "–"
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
@@ -70,6 +87,16 @@ struct PopoverHeaderView: View {
                     .foregroundColor(.primary)
 
                 Spacer()
+
+                // Pin button — detach popover into floating panel (#63)
+                Button(action: { onPinToggled?() }) {
+                    Image(systemName: isPinned ? "pin.fill" : "pin")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(isPinned ? Color(NSColor.controlAccentColor) : Color(NSColor.tertiaryLabelColor))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(isPinned ? "Unpin — return to popover" : "Pin — keep window open")
+                .help(isPinned ? "Unpin (return to popover)" : "Pin (keep window open)")
 
                 // "Updated X ago" — plain language, not "Last beat" jargon (#12)
                 HStack(spacing: 2) {


### PR DESCRIPTION
Closes #63

## What changed

### New behaviour
A 📌 pin button appears in the popover header. Tapping it:
1. Closes the NSPopover
2. Opens a standalone `NSPanel` at `.floating` window level
3. The panel stays visible when clicking away (no transient dismiss)
4. The claw icon, agent list, and all content continue live-updating
5. Tapping the 📌 again (or the panel's close button) unpin — panel closes, popover returns to normal behaviour

### Implementation

**PopoverView.swift**
- Added `isPinned: Bool = false` and `onPinToggled: (() -> Void)? = nil` to `PopoverView`
- Passed both through to `PopoverHeaderView`
- `PopoverHeaderView` gains `isPinned` and `onPinToggled` params
- Pin button in header: `Image(systemName: isPinned ? "pin.fill" : "pin")` — lit accent colour when pinned, tertiary grey when not

**ClawViewApp.swift**
- Added `var floatingPanel: NSPanel?` and `var isPinned: Bool = false`
- `setupPopover()` now passes `onPinToggled: { [weak self] in self?.togglePin() }` to the PopoverView
- `togglePin()` → `pin()` or `unpin()`
- `pin()`: Closes popover → creates `NSPanel` with `.nonactivatingPanel` (doesn't steal focus), `.utilityWindow` (small title bar), `.floating` level → positions near status item → installs `willCloseNotification` observer for clean unpin via close button
- `unpin()`: Closes panel → calls `refreshPopoverContent()` to reset pin button to unlit state
- `refreshPopoverContent()`: Updates the NSHostingController's rootView so the pin button reflects the current state

### Panel properties
- `.nonactivatingPanel` — clicking the panel or its contents doesn't steal focus from the active app
- `.utilityWindow` — compact title bar style
- `isMovableByWindowBackground = true` — drag from anywhere in the window
- `titleVisibility = .hidden` + `titlebarAppearsTransparent = true` — clean look
- Positioned below the status item (near where the popover would appear)

## How to verify
1. Click the claw icon → popover opens → click the 📌 pin button → panel appears, stays open
2. Click away from the panel → stays open
3. Click 📌 again → panel closes, popover behaviour restored
4. Close panel via ✕ button → same unpin behaviour
5. Agent data continues live-updating while panel is open