### PR TITLE
fix: search main sessions for subagent attribution, fix duration_seconds

### DIFF
--- a/clawview-status-server.js
+++ b/clawview-status-server.js
@@ -46,17 +46,24 @@ const AGENT_NAME_TO_ID = {
   'Krill': null, // QA sub-agent, not a top-level agent
 };
 
+// Regex derived from AGENT_NAME_TO_ID keys — single source of truth.
+const AGENT_NAMES_PATTERN = new RegExp(
+  'You are (' + Object.keys(AGENT_NAME_TO_ID).join('|') + ')'
+);
+
 /**
  * Read the first user message from a session JSONL file and extract the agent
  * name from "You are <Name>" patterns. Returns the agent ID string or null.
  */
 function getSubagentOwner(sessionFile) {
   if (!sessionFile || !fs.existsSync(sessionFile)) return null;
+  let fd = null;
   try {
-    const fd = fs.openSync(sessionFile, 'r');
-    const buf = Buffer.alloc(4096); // first 4KB is enough to find the task header
-    const bytesRead = fs.readSync(fd, buf, 0, 4096, 0);
+    fd = fs.openSync(sessionFile, 'r');
+    const buf = Buffer.alloc(16384); // first 16KB — task text can be up to ~8KB
+    const bytesRead = fs.readSync(fd, buf, 0, 16384, 0);
     fs.closeSync(fd);
+    fd = null; // prevent double-close in finally
     const text = buf.slice(0, bytesRead).toString('utf8');
     const lines = text.split('\n');
     for (const line of lines) {
@@ -73,15 +80,21 @@ function getSubagentOwner(sessionFile) {
       } else if (typeof content === 'string') {
         taskText = content;
       }
-      // Match "You are Linus", "You are Steve", etc.
-      const m = taskText.match(/You are (Linus|Steve|Richard|Demis|Prawn|Santa|Clawdia|Krill)/);
+      // Match "You are Linus", "You are Steve", etc. (pattern derived from AGENT_NAME_TO_ID)
+      const m = taskText.match(AGENT_NAMES_PATTERN);
       if (m) {
         return AGENT_NAME_TO_ID[m[1]] || null;
       }
       // Only need the first user message
       break;
     }
-  } catch (e) {}
+  } catch (e) {
+    // Ignore read errors (file may be locked or truncated)
+  } finally {
+    if (fd !== null) {
+      try { fs.closeSync(fd); } catch (e) {}
+    }
+  }
   return null;
 }
 


### PR DESCRIPTION
## Problem

Closes #75

All non-main agents (Linus, Steve, etc.) showed **idle** in ClawView even when actively working. The app was useless for tracking agent activity.

## Root cause

The status server read `~/.openclaw/agents/{agentId}/sessions/sessions.json` for each agent. But **subagent sessions are always stored in `agents/main/sessions/sessions.json`** regardless of which agent was spawned. So `agents/dev/sessions/sessions.json` only had a stale Discord session from yesterday — the server never saw today's work.

## Fix 1 — Subagent session attribution

- Added `MAIN_SESSIONS_FILE` constant pointing to `agents/main/sessions/sessions.json`
- Added `getSubagentOwner(sessionFile)`: reads the first user message of a JSONL session file, matches `You are <Name>` patterns to identify the owning agent
- Added `getMainSubagentSessions()`: cached (5s TTL) map of `agentId → most recent subagent session` built from main's sessions.json
- In `getAgentStatusV2()`: if main's subagent map has a more-recent session for this agent, it overrides the (stale) own-dir session

## Fix 2 — duration_seconds

- **Before:** `Math.floor((lastActivityMs - sessionStartedAt) / 1000)` — total session age since start
- **After:** `Math.floor(activityAgeMs / 1000)` — time since last activity
- Agent that last acted 2 minutes ago now shows `2m`, not `19h`

## How to verify

1. Restart the status server
2. While a subagent is running, hit `/api/sessions/active`
3. The agent (Linus/Steve/etc.) should now show `active` status with real activity text
4. `duration_seconds` should reflect minutes since last action, not hours of session age