### PR TITLE
fix: correctly strip env-var prefixes including quoted values and command substitution

### DIFF
--- a/clawview-status-server.js
+++ b/clawview-status-server.js
@@ -204,9 +204,24 @@ function humaniseToolCall(name, args) {
 
       // Strip cd prefix (cd /path && actual-command)
       const withoutCd = cmd.replace(/^cd\s+\S+\s*&&\s*/, '').trim();
-      // Strip env var prefix (VARNAME=value command)
-      const withoutEnv = withoutCd.replace(/^(?:[A-Z_]+=\S+\s+)+/, '').trim();
-      const effective = withoutEnv || withoutCd || cmd;
+      // Strip env var prefixes (VARNAME=value command), including:
+      //   - Simple:            VAR=foo
+      //   - Single-quoted:     VAR='foo bar'
+      //   - Double-quoted:     VAR="foo bar"
+      //   - Command subst:     VAR="$(security find...)" — may contain spaces inside quotes
+      // Strategy: consume one assignment token at a time from the left.
+      function stripEnvVars(str) {
+        const envVarRe = /^[A-Z_][A-Z0-9_]*=(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S+)\s*/;
+        let s = str;
+        let prev;
+        do {
+          prev = s;
+          s = s.replace(envVarRe, '');
+        } while (s !== prev && s.length > 0);
+        return s.trim();
+      }
+      const withoutEnv = stripEnvVars(withoutCd) || withoutCd;
+      const effective = withoutEnv || cmd;
       const firstWord = effective.split(/\s+/)[0];
       const restWords = effective.split(/\s+/).slice(1, 4).join(' ');
 


### PR DESCRIPTION
## Problem

The env-var strip regex `/^(?:[A-Z_]+=\S+\s+)+/` used `\S+` to match the assignment value, which stops at the first whitespace. Commands like:

```
GOG_KEYRING_PASSWORD="$(security find-generic-password -a clawdia -s gmail)" gog mail list
```

would only partially match because the command substitution contains spaces. The leftover garbage became `firstWord`, so everything fell back to 'Running command'.

## Fix

Replaced with `stripEnvVars()` — a loop that consumes one assignment token at a time using a regex that correctly handles:
- Double-quoted values: `VAR="foo bar"`
- Single-quoted values: `VAR='foo bar'`
- Command substitution: `VAR="$(security find...)"`
- Multiple env vars in sequence: `FOO=bar BAZ=qux git push` → `git push`

## Testing

Unit-tested in-process with 6 cases, all pass.

Closes #82