### PR TITLE
fix: increase ACTIVE_WINDOW_MS from 2 to 5 minutes

### DIFF
--- a/clawview-status-server.js
+++ b/clawview-status-server.js
@@ -161,7 +161,7 @@ const AGENT_META = {
 // ─── Thresholds ──────────────────────────────────────────────────────────────
 
 // An agent is "active" (not just idle) if its last session activity was within this window
-const ACTIVE_WINDOW_MS        = 2 * 60 * 1000;   // 2 minutes — session must be live-ish to show active
+const ACTIVE_WINDOW_MS        = 5 * 60 * 1000;   // 5 minutes — LLM inference + tool chains can go quiet for 2-5 min
 // Within an active session, flag as "stuck" if silent for this long
 const STUCK_THRESHOLD_MS      = 10 * 60 * 1000;  // 10 minutes (per spec)
 // If idle for more than this, show generic idle text rather than last message


### PR DESCRIPTION
## Problem

`ACTIVE_WINDOW_MS = 2 * 60 * 1000` (2 minutes) is too short. During normal LLM inference, especially long tool chains with multiple file reads, builds, and API calls, sessions can go quiet for 2-5 minutes. This causes agents to flip to 'idle' while they're actively mid-task.

## Fix

Changed to 5 minutes. `STUCK_THRESHOLD_MS` remains at 10 minutes (unchanged).

Timeline:
- 0–5 min since last activity: **active** 
- 5–10 min: **active** (was idle before this fix)
- 10+ min: **stuck**
- Session file not updated: **idle**

Closes #84