### PR TITLE
fix: deduplicate consecutive identical entries in recent activity feed

### DIFF
--- a/clawview-status-server.js
+++ b/clawview-status-server.js
@@ -569,9 +569,12 @@ function parseSessionFile(sessionFile) {
 
         // Build recent activity entries (last 8, within 24h window)
         // For entries: prefer tool call text (more granular) over assistant narration
+        // Deduplicate: skip consecutive identical entries (e.g. 8x "Reading file")
         if (ts > 0 && (now - ts) < ENTRY_WINDOW_MS) {
           const entryText = messageToolCall || messageText;
-          if (entryText && result.recentEntries.length < 8) {
+          const lastEntry = result.recentEntries[0]; // most recent (we unshift)
+          const isDuplicate = lastEntry && lastEntry.text === entryText;
+          if (entryText && !isDuplicate && result.recentEntries.length < 8) {
             result.recentEntries.unshift({
               time: new Date(ts).toISOString(),
               text: entryText,


### PR DESCRIPTION
## Problem

The same activity text could appear 8 times in a row in `_recentActivity`. When an agent makes many calls to the same tool in sequence (e.g. 8 file reads), all 8 slots fill with `"Reading file"`.

## Fix

Before adding a new entry to `recentEntries`, check if the most-recently-added entry has the same text. If so, skip it. Non-consecutive duplicates (e.g. Read → Write → Read) are preserved.

Closes #86