### PR TITLE
fix: increase getSubagentOwner() read buffer from 16KB to 64KB

### DIFF
--- a/clawview-status-server.js
+++ b/clawview-status-server.js
@@ -60,8 +60,8 @@ function getSubagentOwner(sessionFile) {
   let fd = null;
   try {
     fd = fs.openSync(sessionFile, 'r');
-    const buf = Buffer.alloc(16384); // first 16KB — task text can be up to ~8KB
-    const bytesRead = fs.readSync(fd, buf, 0, 16384, 0);
+    const buf = Buffer.alloc(65536); // first 64KB — skills preamble alone can be 40KB+, "You are Steve" appears after that
+    const bytesRead = fs.readSync(fd, buf, 0, 65536, 0);
     fs.closeSync(fd);
     fd = null; // prevent double-close in finally
     const text = buf.slice(0, bytesRead).toString('utf8');


### PR DESCRIPTION
## Problem

`getSubagentOwner()` reads the first 16KB of a session JSONL file to find the `"You are Linus"` / `"You are Steve"` pattern in the first user message. However, the available_skills XML preamble injected at session start can be 40KB+ on its own. This means the agent attribution text appears AFTER the 16KB boundary and is never found.

Result: all subagent sessions appear in `_recentActivity` but are attributed to `null` instead of the correct top-level agent (Linus, Steve, etc.).

## Fix

Increased buffer from 16,384 to 65,536 bytes (64KB). The preamble + task text fits well within 64KB for all known configurations.

Closes #87