### PR TITLE
fix: show duration_seconds as 'Xm ago' not 'X min' to clarify meaning

### DIFF
--- a/ClawView/ClawView/Views/AgentCardView.swift
+++ b/ClawView/ClawView/Views/AgentCardView.swift
@@ -67,7 +67,8 @@ struct AgentCardView: View {
                     // Idle agents: show "Last active X ago" instead
                     if agent.isActive && agent.durationSeconds > 0 {
                         HStack(spacing: 4) {
-                            Image(systemName: "clock")
+                            // clock.arrow.circlepath communicates "time ago" not "elapsed duration" (#85)
+                            Image(systemName: "clock.arrow.circlepath")
                                 .font(.system(size: 10))
                                 .foregroundColor(Color(NSColor.tertiaryLabelColor))
 
@@ -184,13 +185,15 @@ struct AgentCardView: View {
             .trimmingCharacters(in: .whitespaces)
     }
 
+    /// duration_seconds = time since last activity, NOT session duration.
+    /// Display as "Xm ago" / "Xh ago" to make this clear to the reader (#85).
     private var formattedDuration: String {
         let secs = agent.durationSeconds
-        if secs < 60 { return "\(secs)s" }
+        if secs < 60 { return "\(secs)s ago" }
         let mins = secs / 60
-        if mins < 60 { return "\(mins) min" }
+        if mins < 60 { return "\(mins)m ago" }
         let hours = mins / 60
-        return "\(hours)h \(mins % 60)m"
+        return "\(hours)h \(mins % 60)m ago"
     }
 
     private var healthColor: Color {


### PR DESCRIPTION
## Problem

The duration row in each agent card shows a clock icon + `4 min`. Jack reads this as "has been working for 4 minutes" — but `duration_seconds` is actually **time since last activity** (how long ago the agent last did something), not session duration.

## Fix

1. `formattedDuration` now appends `"ago"`: `4s ago`, `4m ago`, `2h 3m ago`
2. Icon changed from `"clock"` to `"clock.arrow.circlepath"` — the circular arrow communicates "time since" rather than "elapsed"
3. Added doc comment on `formattedDuration` explaining what `duration_seconds` represents

## Before / After

| Before | After |
|--------|-------|
| 🕐 4 min | 🔄 4m ago |
| 🕐 1h 30m | 🔄 1h 30m ago |

Closes #85