### PR TITLE
fix: reduce heartbeatIsStale threshold from 300s to 90s

### DIFF
--- a/ClawView/ClawView/Services/GatewayService.swift
+++ b/ClawView/ClawView/Services/GatewayService.swift
@@ -290,9 +290,12 @@ class GatewayService: ObservableObject {
         return "\(elapsed / 60)m"
     }
 
+    /// True when no successful gateway response for > 90 seconds (#88).
+    /// At 5s base poll interval, 90s = ~3 failed retries. Fast enough to warn
+    /// while not triggering on transient connectivity blips.
     var heartbeatIsStale: Bool {
         guard let lastHeartbeat = lastHeartbeat else { return true }
-        return Date().timeIntervalSince(lastHeartbeat) > 300
+        return Date().timeIntervalSince(lastHeartbeat) > 90
     }
 
     // MARK: - Connection State Inference (#37)

--- a/ClawView/ClawView/Views/PopoverView.swift
+++ b/ClawView/ClawView/Views/PopoverView.swift
@@ -114,13 +114,15 @@ struct PopoverHeaderView: View {
             .frame(height: 56)
 
             // Stale data warning banner (#43) — shown when no gateway response for > 5 minutes.
-            // heartbeatIsStale is a computed var on GatewayService (> 300s).
+            // heartbeatIsStale is a computed var on GatewayService (> 90s, #88).
+            // Reduced from 300s: 90s = ~3 missed poll cycles — fast enough to warn
+            // without false-alarming on transient connectivity blips.
             if gateway.heartbeatIsStale {
                 HStack(spacing: 6) {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.system(size: 11, weight: .semibold))
                         .accessibilityHidden(true)  // text label conveys the meaning (#39)
-                    Text("Data may be outdated — last updated \(heartbeatAge) ago")
+                    Text("Gateway unreachable — data is \(heartbeatAge) old")
                         .font(.caption2)
                         .lineLimit(1)
                 }


### PR DESCRIPTION
## Problem

When the status server crashes, ClawView shows stale agent data for up to **5 minutes** before showing the stale-data warning banner. The icon goes red (good), but the popover still shows stale data with only `Updated Xm ago` — not enough signal.

## Fix

1. **Threshold: 300s → 90s** — at 5s base poll interval, 90s = ~3 failed retries. Fast enough to warn promptly without false-alarming on 1–2 transient network blips.

2. **Banner text improved:** `"Data may be outdated — last updated Xm ago"` → `"Gateway unreachable — data is Xm old"` — more specific about what happened and more direct about the data being stale.

## Why not shorter?

5s is a transient blip (single failed poll). 30s = 2 failures (might be slow gateway). 90s = 3+ failures in a row = almost certainly crashed or unreachable.

Closes #88