### PR TITLE
fix: sessionStartedAt now reliable for large sessions

### DIFF
--- a/clawview-status-server.js
+++ b/clawview-status-server.js
@@ -466,7 +466,10 @@ function parseSessionFile(sessionFile) {
 
     const lines = buf.toString('utf8').split('\n').filter(l => l.trim());
 
-    // Also get the first line for session start time
+    // For large sessions: read the first line separately to get the true session start time.
+    // The backwards scan only sees the last 32KB, so the earliest entry in that window
+    // is NOT the real start. This dedicated read gives the correct sessionStartedAt. (#90)
+    let sessionStartSetFromDedicatedRead = false;
     if (stat.size > readSize) {
       try {
         const startBuf = Buffer.alloc(512);
@@ -477,6 +480,7 @@ function parseSessionFile(sessionFile) {
         const firstEntry = JSON.parse(firstLine);
         if (firstEntry.timestamp) {
           result.sessionStartedAt = new Date(firstEntry.timestamp).toISOString();
+          sessionStartSetFromDedicatedRead = true;
         }
       } catch (e) {}
     }
@@ -582,8 +586,12 @@ function parseSessionFile(sessionFile) {
           }
         }
 
-        // Set sessionStartedAt from first-pass scan (we're going backwards so last one wins = earliest)
-        if (ts > 0 && (!result.sessionStartedAt || ts < new Date(result.sessionStartedAt).getTime())) {
+        // Set sessionStartedAt from backwards scan ONLY for small sessions (fits in 32KB).
+        // For large sessions, sessionStartSetFromDedicatedRead=true — the 512-byte start
+        // buffer already read the true session start. Don't override it with an entry
+        // from the middle of the session. (#90)
+        if (!sessionStartSetFromDedicatedRead && ts > 0 &&
+            (!result.sessionStartedAt || ts < new Date(result.sessionStartedAt).getTime())) {
           result.sessionStartedAt = new Date(ts).toISOString();
         }
       }


### PR DESCRIPTION
## Problem

`parseSessionFile()` reads only the last 32KB of a session JSONL. For large sessions, the backwards scan finds the 'earliest entry in the 32KB window' — which is from the *middle* of the session, not the true start. A 2-hour session shows its start time as 'T-10 minutes ago'.

The 512-byte start-buffer read was already correct but the backwards scan overwrote it.

## Fix

Added `sessionStartSetFromDedicatedRead` flag. When the dedicated start-buffer read succeeds (only happens for large sessions, `stat.size > readSize`), the backwards scan skips `sessionStartedAt` updates entirely — the 512-byte read gave the correct answer.

Small sessions (fit in 32KB) are unaffected: the dedicated read block doesn't run for them, so the backwards scan still finds the true earliest entry.

Closes #90