### PR TITLE
fix: show Demis/research as idle when no sessions.json exists

### DIFF
--- a/clawview-status-server.js
+++ b/clawview-status-server.js
@@ -653,7 +653,9 @@ function getAgentStatusV2(agentId) {
   let sessions = {};
   if (fs.existsSync(sessionsFile)) {
     try {
-      sessions = JSON.parse(fs.readFileSync(sessionsFile, 'utf8'));
+      // Guard: JSON.parse can return null/string/array — ensure we always have a plain object.
+      // Object.entries(null) throws TypeError; || {} prevents that edge case.
+      sessions = JSON.parse(fs.readFileSync(sessionsFile, 'utf8')) || {};
     } catch (e) {
       // Corrupted sessions.json — treat as empty, agent will show idle
     }


### PR DESCRIPTION
## Summary

Closes #95

Demis (research agent) was silently absent from every ClawView API response. Root cause: `getAgentStatusV2()` returned `null` when an agent had no `sessions.json` — which is the case for Demis since he's never been directly activated as a top-level agent session.

## What changed

**`clawview-status-server.js`**

1. `AGENT_META` already contained the `research` entry (name: Demis, emoji: 🔬, role: Research, channel: 1480700259285074033) — no change needed there.

2. `getAgentStatusV2()`: replaced two early `return null` paths:
   - `if (!fs.existsSync(sessionsFile)) return null` → now initialises `sessions = {}` and continues
   - `if (!bestSession || !bestKey) return null` → now returns a stub idle entry:
     ```
     { agent_id, display_name, status: 'idle', activity: 'Idle — never activated', ... }
     ```
   This means every agent in `AGENT_META` always appears in the response, even if it has zero session history.

## How to verify

```bash
curl -s http://127.0.0.1:7317/api/clawview/status | python3 -m json.tool | grep -A 5 'research'
```

Expected: `"id": "research"`, `"name": "Demis"`, `"status": "idle"`

## Decisions

- Used `activity: 'Idle — never activated'` rather than generic `'Idle'` so it's distinguishable from a normally-idle agent
- `last_activity_at` set to epoch (`new Date(0)`) to indicate no prior activity, not a stale timestamp
- All V1 compat fields included in the stub so legacy ClawView app shape is unchanged