### PR TITLE
fix: handle unquoted command substitution in stripEnvVars (#105)

### DIFF
--- a/clawview-status-server.js
+++ b/clawview-status-server.js
@@ -224,7 +224,12 @@ function humaniseToolCall(name, args) {
       //   - Command subst:     VAR="$(security find...)" — may contain spaces inside quotes
       // Strategy: consume one assignment token at a time from the left.
       function stripEnvVars(str) {
-        const envVarRe = /^[A-Z_][A-Z0-9_]*=(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S+)\s*/;
+        // Value alternatives (in order):
+        //   "..."        — double-quoted (may contain spaces, escaped chars)
+        //   '...'        — single-quoted (may contain spaces, escaped chars)
+        //   $(...)       — unquoted command substitution (may contain spaces)
+        //   \S+          — unquoted simple value (no spaces)
+        const envVarRe = /^[A-Z_][A-Z0-9_]*=(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\$\([^)]*\)|\S+)\s*/;
         let s = str;
         let prev;
         do {


### PR DESCRIPTION
## Problem

`stripEnvVars` was not stripping env var prefixes with unquoted command substitutions containing spaces.

Example: `VAR=$(security find-generic-password -w) git push`

The regex value pattern ended with `|\S+` which stops at the first space. Inside `$(security find-generic-password -w)` there are spaces, so the match fails at `$(security` and the whole env var prefix is left un-stripped.

## Fix

Added `|\$\([^)]*\)` as an alternative before `\S+` in the regex. This matches a complete unquoted `$(...)` command substitution as a single token, consuming all content up to the closing `)`.

## Test cases

- `VAR=$(security find-generic-password -w) git push` → `git push` ✓
- `GH_TOKEN=$(cat ~/.token) gh pr list` → `gh pr list` ✓  
- `VAR=simple git status` → `git status` ✓ (unchanged, `\S+` still handles this)
- `VAR='quoted value' git commit` → `git commit` ✓ (unchanged)
- `VAR="double quoted" git pull` → `git pull` ✓ (unchanged)
- `VAR=$(nested $(cmd)) git push` → not fully handled (nested parens), acceptable — vanishingly rare

Closes #105