### PR TITLE
fix: use token-based cost estimate when JSONL cost is zero (#94)

### DIFF
--- a/clawview-status-server.js
+++ b/clawview-status-server.js
@@ -564,10 +564,13 @@ function parseSessionFile(sessionFile) {
         const content = msg.content;
         const usage = msg.usage;
 
-        // Extract cost from usage
+        // Extract cost from usage — only capture non-zero values.
+        // The Gateway often returns usage.cost.total = 0 for subagent sessions
+        // (billing handled at the provider level, not per-message). Zero is not
+        // meaningful here and blocks the token-based fallback below.
         if (!result.cost && usage && usage.cost) {
           const total = usage.cost.total;
-          if (typeof total === 'number') {
+          if (typeof total === 'number' && total > 0) {
             result.cost = total;
           }
         }
@@ -836,9 +839,11 @@ function getAgentStatusV2(agentId) {
   }
 
   // ── Session cost ───────────────────────────────────────────────────────────
-  // Accumulate cost from session metadata if available
+  // Accumulate cost from session metadata if available.
+  // Fall back to token-based estimate when JSONL cost is null OR zero.
+  // Zero means the Gateway didn't populate cost (common for subagent sessions).
   let costUsd = parsed.cost;
-  if (costUsd === null && bestSession.inputTokens) {
+  if ((costUsd === null || costUsd === 0) && bestSession.inputTokens) {
     // Rough estimate: claude-4-x pricing ~$3/M input, ~$15/M output
     const inputCost = (bestSession.inputTokens || 0) / 1_000_000 * 3.0;
     const outputCost = (bestSession.outputTokens || 0) / 1_000_000 * 15.0;


### PR DESCRIPTION
## Problem

Subagent sessions showed `$0.00` cost in ClawView.

**Root cause:** The Gateway populates `usage.cost.total = 0` in subagent session JSONL messages (billing is handled at provider level, not per-message). `parseSessionFile()` read this `0` and stored it as `parsed.cost`. The token-based fallback only checked `costUsd === null`, so a `costUsd = 0` bypassed it and displayed as `$0.00`.

Verified by inspecting a live subagent JSONL (60 messages, all with `usage.cost.total = 0`).

## Fix

**Two changes:**

1. `parseSessionFile`: only store JSONL cost when `total > 0`. Zero is not meaningful — it just means the Gateway didn't populate this field.

2. Cost section: fall back to token-based estimate when `costUsd === null || costUsd === 0`. Token counts (`inputTokens`, `outputTokens`, `cacheRead`, `cacheWrite`) are present in `sessions.json` and give accurate estimates.

## Verification

Session `9e6c97d6` (active Linus subagent) has:
- `inputTokens: 54, outputTokens: 10585, cacheRead: 1798602, cacheWrite: 46497`
- Estimated cost: ~$0.87 (dominated by cache reads)

This will now display correctly instead of $0.00.

Closes #94