### PR TITLE
chore: fix Info.plist version — was hardcoded to 0.1.0, update to 0.2.0

### DIFF
--- a/ClawView/ClawView/Info.plist
+++ b/ClawView/ClawView/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Info.plist had hardcoded CFBundleShortVersionString=0.1.0 which was overriding the pbxproj MARKETING_VERSION setting. Update to 0.2.0 to match.