### PR TITLE
fix: use last assistant message timestamp for idle agent display (#142)

### DIFF
--- a/clawview-status-server.js
+++ b/clawview-status-server.js
@@ -784,11 +784,15 @@ function getAgentStatusV2(agentId) {
   // Parse the session file for detailed activity
   const parsed = parseSessionFile(bestSession.sessionFile);
 
-  // Use the more recent of: session updatedAt vs parsed lastActivityMs
-  const lastActivityMs = Math.max(
-    bestUpdatedAt,
-    parsed.lastActivityMs || 0
-  );
+  // For idle timestamp accuracy (#142): prefer the last role:assistant message timestamp
+  // from the JSONL over session.updatedAt. The session file is touched by heartbeats,
+  // system events, and subagent writes — none of which represent meaningful agent work.
+  // parsed.lastActivityMs is set only when an actual assistant message is found in the
+  // JSONL, so it reflects when the agent last genuinely responded.
+  // Fall back to bestUpdatedAt only if the JSONL has no parseable assistant messages.
+  const lastActivityMs = parsed.lastActivityMs > 0
+    ? parsed.lastActivityMs
+    : bestUpdatedAt;
   const activityAgeMs = now - lastActivityMs;
 
   // ── Status determination ──────────────────────────────────────────────────


### PR DESCRIPTION
## What changed and why

The server was using `session.updatedAt` for idle agent 'last active X ago' timestamps. This field gets touched by heartbeats and system events — not just meaningful agent work — causing idle agents to show misleadingly recent timestamps.

**Root cause:** `lastActivityMs = Math.max(bestUpdatedAt, parsed.lastActivityMs || 0)` — `bestUpdatedAt` (file mod time) was always >= parsed activity, so it always won.

**Fix:** Use `parsed.lastActivityMs` when available (derived from the last `role:assistant` message in the JSONL). Only fall back to `bestUpdatedAt` when no assistant messages exist in the session at all.

## How to test / verify
```bash
curl -s http://127.0.0.1:7317/api/clawview/status | python3 -c "import json,sys; d=json.load(sys.stdin); [print(f'{a[\"name\"]}: {a[\"status\"]} — {a[\"activity\"]} (last: {a[\"last_activity\"]})') for a in d['agents']]"
```
Idle agents should now show timestamps that correspond to when they last actually responded (not when heartbeats last touched their session file).

Closes #142