### PR TITLE
fix: pinned panel shows all agents — preferredContentSize + minHeight (#141), v0.3.2

### DIFF
--- a/ClawView/ClawView.xcodeproj/project.pbxproj
+++ b/ClawView/ClawView.xcodeproj/project.pbxproj
@@ -313,7 +313,7 @@
 				CODE_SIGN_ENTITLEMENTS = ClawView/ClawView.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -325,7 +325,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.3.1;
+				MARKETING_VERSION = 0.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.openclaw.ClawView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -342,7 +342,7 @@
 				CODE_SIGN_ENTITLEMENTS = ClawView/ClawView.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -354,7 +354,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.3.1;
+				MARKETING_VERSION = 0.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.openclaw.ClawView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/ClawView/ClawView/ClawViewApp.swift
+++ b/ClawView/ClawView/ClawViewApp.swift
@@ -238,11 +238,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             panel.center()
         }
 
-        panel.contentViewController = NSHostingController(rootView: pinnedView)
-        // Fix #141: NSHostingController doesn't inherit the panel's contentRect size
-        // automatically — SwiftUI collapses or clips the ScrollView content without an
-        // explicit frame on the hosting view. Set it explicitly to match the panel size.
-        panel.contentViewController?.view.frame = NSRect(x: 0, y: 0, width: 320, height: 540)
+        let hostingController = NSHostingController(rootView: pinnedView)
+        // Fix #141: set preferredContentSize so NSHostingController tells SwiftUI exactly
+        // how much space it has. Without this the ScrollView sizes to its natural minimum
+        // (one card) and ignores the panel's contentRect entirely.
+        hostingController.preferredContentSize = NSSize(width: 320, height: 540)
+        panel.contentViewController = hostingController
+        hostingController.view.frame = NSRect(x: 0, y: 0, width: 320, height: 540)
 
         // When the panel is closed via the close button, unpin cleanly
         NotificationCenter.default.addObserver(

--- a/ClawView/ClawView/Info.plist
+++ b/ClawView/ClawView/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.1</string>
+	<string>0.3.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ClawView/ClawView/Views/PopoverView.swift
+++ b/ClawView/ClawView/Views/PopoverView.swift
@@ -232,7 +232,7 @@ struct AgentListView: View {
             }
             .padding(.vertical, 8)
         }
-        .frame(maxHeight: 540) // 640 - 56 (header) - 44 (footer) — v1.1 height fix
+        .frame(minHeight: 440, maxHeight: 540) // min forces panel to expand; max caps popover — fix #141
         .scrollIndicators(.hidden)
         // Mark first load complete as soon as gateway responds (#132)
         // Use lastHeartbeat as the signal — it's set on every successful fetch


### PR DESCRIPTION
Fixes #141. Two changes:
1. NSHostingController.preferredContentSize set to 320×540 — without this SwiftUI's ScrollView has no proposed height and sizes to its natural minimum (one card).
2. ScrollView .frame(maxHeight:540) → .frame(minHeight:440, maxHeight:540) — forces the scroll area to expand in the panel context.
Also bumps version to 0.3.2.