### PR TITLE
fix: pinned panel shows all agents, no crash — fixed height via isPinned (#141), v0.3.3

### DIFF
--- a/ClawView/ClawView.xcodeproj/project.pbxproj
+++ b/ClawView/ClawView.xcodeproj/project.pbxproj
@@ -313,7 +313,7 @@
 				CODE_SIGN_ENTITLEMENTS = ClawView/ClawView.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -325,7 +325,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.openclaw.ClawView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -342,7 +342,7 @@
 				CODE_SIGN_ENTITLEMENTS = ClawView/ClawView.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -354,7 +354,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.openclaw.ClawView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/ClawView/ClawView/ClawViewApp.swift
+++ b/ClawView/ClawView/ClawViewApp.swift
@@ -239,12 +239,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let hostingController = NSHostingController(rootView: pinnedView)
-        // Fix #141: set preferredContentSize so NSHostingController tells SwiftUI exactly
-        // how much space it has. Without this the ScrollView sizes to its natural minimum
-        // (one card) and ignores the panel's contentRect entirely.
-        hostingController.preferredContentSize = NSSize(width: 320, height: 540)
         panel.contentViewController = hostingController
-        hostingController.view.frame = NSRect(x: 0, y: 0, width: 320, height: 540)
 
         // When the panel is closed via the close button, unpin cleanly
         NotificationCenter.default.addObserver(

--- a/ClawView/ClawView/Info.plist
+++ b/ClawView/ClawView/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.2</string>
+	<string>0.3.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ClawView/ClawView/Views/PopoverView.swift
+++ b/ClawView/ClawView/Views/PopoverView.swift
@@ -28,7 +28,9 @@ struct PopoverView: View {
                 mainContent
             }
         }
-        .frame(width: 320)
+        // In panel mode, SwiftUI must own the height — NSPanel doesn't propose a size.
+        // In popover mode, the popover's contentSize owns the height — don't override it.
+        .frame(width: 320, height: isPinned ? 540 : nil)
     }
 
     @ViewBuilder
@@ -232,7 +234,7 @@ struct AgentListView: View {
             }
             .padding(.vertical, 8)
         }
-        .frame(minHeight: 440, maxHeight: 540) // min forces panel to expand; max caps popover — fix #141
+        .frame(maxHeight: 540)
         .scrollIndicators(.hidden)
         // Mark first load complete as soon as gateway responds (#132)
         // Use lastHeartbeat as the signal — it's set on every successful fetch


### PR DESCRIPTION
Fixes #141. Previous attempt (PR #147) crashed with SIGABRT — minHeight constraint fought AppKit's layout engine causing an unresolvable constraint abort.

Root cause: NSPanel doesn't propose a size to SwiftUI, so the ScrollView collapsed. The correct fix is to have SwiftUI own the height when in panel mode via a fixed .frame(height: 540) — but only in panel mode (not popover mode where NSPopover owns the height).

Change: PopoverView body now uses .frame(width: 320, height: isPinned ? 540 : nil). When pinned, SwiftUI sizes itself to exactly 540pt. When in popover, nil lets the popover's contentSize control height as before. No constraint conflicts, no crash.

Also reverts the minHeight:440 that caused the crash.